### PR TITLE
Update Android Gradle Plugin version for Chromecast Sample App

### DIFF
--- a/ChromecastSampleApp/build.gradle
+++ b/ChromecastSampleApp/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle:1.0.0'
+        classpath 'com.android.tools.build:gradle:1.5.0'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files


### PR DESCRIPTION
Gradle 2.4 sets the minimum gradle plugin version to be 1.3, which causes build failures in ChromecastSampleApp.

Intentionally on Stable to fix Sample App build
