### PR TITLE
AddingPermissionsToExoPlayerAutomationHook

### DIFF
--- a/ExoPlayerSampleApp/app/src/main/AndroidManifest.xml
+++ b/ExoPlayerSampleApp/app/src/main/AndroidManifest.xml
@@ -7,6 +7,7 @@
     <uses-permission android:name="android.permission.INTERNET" />
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
+    <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
Added write_external_storage permission in Android manifest of exoplayer for automation hook to work .
