### PR TITLE
[PBA-4685] Fix Pulse SampleApp  to have correct build tools version

### DIFF
--- a/PulseSampleApp/app/build.gradle
+++ b/PulseSampleApp/app/build.gradle
@@ -1,7 +1,7 @@
 apply plugin: 'com.android.application'
 
 android {
-    buildToolsVersion "21.1.2"
+    buildToolsVersion "23.0.3"
     compileSdkVersion 23
 
     defaultConfig {


### PR DESCRIPTION
Build tools version should be the same as the support libraries used
