### PR TITLE
[PBA-5641] Add commented dexOptions

### DIFF
--- a/ExoPlayerSampleApp/app/build.gradle
+++ b/ExoPlayerSampleApp/app/build.gradle
@@ -33,6 +33,7 @@ android {
 // Uncomment if you need multidex
 //  dexOptions {
 //    javaMaxHeapSize "4g"
+//    jumboMode true
 //  }
 }
 

--- a/PulseSampleApp/app/build.gradle
+++ b/PulseSampleApp/app/build.gradle
@@ -21,6 +21,11 @@ android {
             proguardFiles getDefaultProguardFile('proguard-android.txt'), 'proguard-rules.txt'
         }
     }
+
+//    dexOptions {
+//        javaMaxHeapSize "4g"
+//        jumboMode true
+//    }
 }
 task copyLibsTask(type: Copy) {
     from new File(vendorDir, 'Ooyala/OoyalaPulseIntegration-Android/OoyalaPulseIntegration.jar')


### PR DESCRIPTION
In lower versions of Android we’re getting a DexIndexOverFlowException, the jumboMode flag works around it.

When you encounter this error, uncomment the dexOptions block and the jumboMode flag.