### PR TITLE
[PBA-5687] Ask for WRITE_EXTERNAL_STORAGE permission on runtime

### DIFF
--- a/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/lists/BasicPlaybackListActivity.java
+++ b/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/lists/BasicPlaybackListActivity.java
@@ -42,9 +42,9 @@ public class BasicPlaybackListActivity extends Activity implements OnItemClickLi
 
     selectionMap = new LinkedHashMap<String, PlayerSelectionOption>();
     //Populate the embed map
-    selectionMap.put("Widevine DASH Stream", new PlayerSelectionOption("tyb2g2NjE64BuIcLQyS0wEccq4fr5Y03", OoyalaSkinOPTPlayerActivity.class));
-    selectionMap.put("Widevine DASH Downloader", new PlayerSelectionOption("tyb2g2NjE64BuIcLQyS0wEccq4fr5Y03", OfflineDownloadActivity.class));
-    selectionMap.put("Widevine DASH Offline Player", new PlayerSelectionOption("tyb2g2NjE64BuIcLQyS0wEccq4fr5Y03", OfflineSkinPlayerActivity.class));
+    selectionMap.put("Widevine DASH Stream", new PlayerSelectionOption("BjN213NzE6H-9WPurASHfKFOtEak5x6b", OoyalaSkinOPTPlayerActivity.class));
+    selectionMap.put("Widevine DASH Downloader", new PlayerSelectionOption("BjN213NzE6H-9WPurASHfKFOtEak5x6b", OfflineDownloadActivity.class));
+    selectionMap.put("Widevine DASH Offline Player", new PlayerSelectionOption("BjN213NzE6H-9WPurASHfKFOtEak5x6b", OfflineSkinPlayerActivity.class));
 
     setContentView(R.layout.list_activity_layout);
 

--- a/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/lists/BasicPlaybackListActivity.java
+++ b/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/lists/BasicPlaybackListActivity.java
@@ -42,9 +42,9 @@ public class BasicPlaybackListActivity extends Activity implements OnItemClickLi
 
     selectionMap = new LinkedHashMap<String, PlayerSelectionOption>();
     //Populate the embed map
-    selectionMap.put("Widevine DASH Stream", new PlayerSelectionOption("BjN213NzE6H-9WPurASHfKFOtEak5x6b", OoyalaSkinOPTPlayerActivity.class));
-    selectionMap.put("Widevine DASH Downloader", new PlayerSelectionOption("BjN213NzE6H-9WPurASHfKFOtEak5x6b", OfflineDownloadActivity.class));
-    selectionMap.put("Widevine DASH Offline Player", new PlayerSelectionOption("BjN213NzE6H-9WPurASHfKFOtEak5x6b", OfflineSkinPlayerActivity.class));
+    selectionMap.put("Widevine DASH Stream", new PlayerSelectionOption("tyb2g2NjE64BuIcLQyS0wEccq4fr5Y03", OoyalaSkinOPTPlayerActivity.class));
+    selectionMap.put("Widevine DASH Downloader", new PlayerSelectionOption("tyb2g2NjE64BuIcLQyS0wEccq4fr5Y03", OfflineDownloadActivity.class));
+    selectionMap.put("Widevine DASH Offline Player", new PlayerSelectionOption("tyb2g2NjE64BuIcLQyS0wEccq4fr5Y03", OfflineSkinPlayerActivity.class));
 
     setContentView(R.layout.list_activity_layout);
 

--- a/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/players/OfflineDownloadActivity.java
+++ b/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/players/OfflineDownloadActivity.java
@@ -4,9 +4,13 @@ import android.app.Activity;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
+import android.support.annotation.NonNull;
+import android.support.v4.app.ActivityCompat;
+import android.support.v4.content.ContextCompat;
 import android.view.View;
 import android.widget.Button;
 import android.widget.TextView;
+import android.widget.Toast;
 
 import com.ooyala.android.EmbedTokenGenerator;
 import com.ooyala.android.EmbedTokenGeneratorCallback;
@@ -21,8 +25,13 @@ import java.net.URL;
 import java.util.HashMap;
 import java.util.List;
 
+import static android.Manifest.permission.WRITE_EXTERNAL_STORAGE;
+import static android.content.pm.PackageManager.PERMISSION_GRANTED;
+
 public class OfflineDownloadActivity extends Activity implements DashDownloader.Listener, EmbedTokenGenerator {
   final String TAG = this.getClass().toString();
+
+  private static final int PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE = 1;
 
   String EMBED = null;
   final String PCODE  = "BjcWYyOu1KK2DiKOkF41Z2k0X57l";
@@ -66,7 +75,11 @@ public class OfflineDownloadActivity extends Activity implements DashDownloader.
     startButton.setOnClickListener(new View.OnClickListener() {
       @Override
       public void onClick(View v) {
-        downloader.startDownload();
+        if (ContextCompat.checkSelfPermission(OfflineDownloadActivity.this, WRITE_EXTERNAL_STORAGE) != PERMISSION_GRANTED) {
+          ActivityCompat.requestPermissions(OfflineDownloadActivity.this, new String[]{WRITE_EXTERNAL_STORAGE}, PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE);
+        } else {
+          downloader.startDownload();
+        }
       }
     });
 
@@ -139,6 +152,18 @@ public class OfflineDownloadActivity extends Activity implements DashDownloader.
 
       }
     });
+  }
+
+  @Override
+  public void onRequestPermissionsResult(int requestCode, @NonNull String[] permissions, @NonNull int[] grantResults) {
+    if (requestCode == PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE) {
+      if (grantResults.length > 0
+              && grantResults[0] == PERMISSION_GRANTED) {
+        downloader.startDownload();
+      } else {
+        Toast.makeText(this, "You don't have permissions to download in this app", Toast.LENGTH_SHORT).show();
+      }
+    }
   }
 
   @Override

--- a/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/players/OfflineSkinPlayerActivity.java
+++ b/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/players/OfflineSkinPlayerActivity.java
@@ -27,7 +27,7 @@ public class OfflineSkinPlayerActivity extends Activity implements Observer, Def
   final String TAG = this.getClass().toString();
 
   String EMBED = null;
-  final String PCODE  = "FoeG863GnBL4IhhlFC1Q2jqbkH9m";
+  final String PCODE  = "BjcWYyOu1KK2DiKOkF41Z2k0X57l";
   final String DOMAIN = "http://ooyala.com";
 
   // Write the sdk events text along with events count to log file in sdcard if the log file already exists

--- a/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/players/OoyalaSkinOPTPlayerActivity.java
+++ b/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/players/OoyalaSkinOPTPlayerActivity.java
@@ -32,7 +32,7 @@ public class OoyalaSkinOPTPlayerActivity extends Activity
   private static final String TAG = OoyalaSkinOPTPlayerActivity.class.getSimpleName();
 
   String EMBED = null;
-  final String PCODE  = "FoeG863GnBL4IhhlFC1Q2jqbkH9m";
+  final String PCODE  = "BjcWYyOu1KK2DiKOkF41Z2k0X57l";
   final String DOMAIN = "http://ooyala.com";
 
   private final String APIKEY = "";


### PR DESCRIPTION
Since Android 6 (M) we need to ask for permissions explicitly on runtime. Without it DTO cannot start because we cannot create the files or directories needed in the device.