### PR TITLE
Fix build for RC

### DIFF
--- a/AdvancedPlaybackSampleApp/app/src/main/java/com/ooyala/sample/utils/SampleAdPlayer.java
+++ b/AdvancedPlaybackSampleApp/app/src/main/java/com/ooyala/sample/utils/SampleAdPlayer.java
@@ -20,6 +20,7 @@ import com.ooyala.android.OoyalaPlayer.State;
 import com.ooyala.android.StateNotifier;
 import com.ooyala.android.player.PlayerInterface;
 import com.ooyala.android.player.PlayerType;
+import com.ooyala.android.player.exoplayer.PlayerBitmapListener;
 import com.ooyala.android.plugin.LifeCycleInterface;
 
 public class SampleAdPlayer extends LinearLayout implements PlayerInterface,
@@ -196,5 +197,10 @@ public class SampleAdPlayer extends LinearLayout implements PlayerInterface,
   @Override
   public PlayerType getPlayerType() {
     return PlayerType.FLAT_PLAYER;
+  }
+
+  @Override
+  public void createBitmapScreenshot(PlayerBitmapListener playerBitmapListener) {
+    // TODO
   }
 }

--- a/VRSampleApp/app/build.gradle
+++ b/VRSampleApp/app/build.gradle
@@ -62,7 +62,7 @@ tasks.copyFontsAssetsTask.execute()
 task copyTask(type: Copy) {
     from new File(vendorDir, 'Ooyala/OoyalaIMASDK-Android/OoyalaIMASDK.jar')
     from new File(vendorDir, 'Google/ima-android-v374.jar')
-    from new File(vendorDir, 'Ooyala/OoyalaVRSDK-Android/OoyalaVRSDK.aar')
+    from new File(vendorDir, 'Ooyala/OoyalaVRSDK-Android/OoyalaVRSDK.jar')
     from new File(vendorDir, 'Ooyala/OoyalaSDK-Android/OoyalaSDK.aar')
     from new File(vendorDir, 'Ooyala/OoyalaSkinSDK-Android/OoyalaSkinSDK.aar')
     from new File(vendorDir, 'Ooyala/OoyalaSkinSDK-Android/react-native-0.35.0.aar')
@@ -79,7 +79,7 @@ dependencies {
 //    implementation project(':ima')
 
     implementation files('libs/OoyalaSDK.aar')
-    implementation files('libs/OoyalaVRSDK.aar')
+    implementation files('libs/OoyalaVRSDK.jar')
     implementation files('libs/OoyalaSkinSDK.aar')
 
 


### PR DESCRIPTION
I'm going to auto merge this PR because QA is blocked without it.

@IvanSakharovskii, @AlinaVoronkovaEpam, the VR SDK was broken because you copied `OoyalaVRSDK.aar` instead of `OoyalaVRSDK.jar`. I don't see any changes yet in our android-sdk to enable .aar for VR SDK don't know why you decided to do this but it broke the VRSampleApp.