### PR TITLE
[PLAYER-3016] Shifted view is shown for full screen landscape mode

### DIFF
--- a/AdvancedPlaybackSampleApp/app/src/main/java/com/ooyala/sample/utils/SampleAdPlayer.java
+++ b/AdvancedPlaybackSampleApp/app/src/main/java/com/ooyala/sample/utils/SampleAdPlayer.java
@@ -1,17 +1,13 @@
 package com.ooyala.sample.utils;
 
-import java.lang.ref.WeakReference;
-import java.util.Timer;
-import java.util.TimerTask;
-
 import android.content.Context;
+import android.content.res.Configuration;
 import android.graphics.Color;
 import android.os.Handler;
 import android.os.Message;
 import android.view.Gravity;
 import android.view.ViewGroup;
 import android.widget.FrameLayout;
-import android.view.View;
 import android.widget.LinearLayout;
 import android.widget.TextView;
 
@@ -22,6 +18,10 @@ import com.ooyala.android.player.PlayerInterface;
 import com.ooyala.android.player.PlayerType;
 import com.ooyala.android.player.exoplayer.PlayerBitmapListener;
 import com.ooyala.android.plugin.LifeCycleInterface;
+
+import java.lang.ref.WeakReference;
+import java.util.Timer;
+import java.util.TimerTask;
 
 public class SampleAdPlayer extends LinearLayout implements PlayerInterface,
     LifeCycleInterface {
@@ -152,6 +152,11 @@ public class SampleAdPlayer extends LinearLayout implements PlayerInterface,
     if (getParent() != null) {
       ((ViewGroup) getParent()).removeView(this);
     }
+  }
+
+  @Override
+  public void configurationChanged(Configuration newConfig) {
+    // TODO Auto-generated method stub
   }
 
   @Override

--- a/CompleteSampleApp/app/src/main/java/com/ooyala/sample/utils/SampleAdPlayer.java
+++ b/CompleteSampleApp/app/src/main/java/com/ooyala/sample/utils/SampleAdPlayer.java
@@ -5,6 +5,7 @@ import java.util.Timer;
 import java.util.TimerTask;
 
 import android.content.Context;
+import android.content.res.Configuration;
 import android.graphics.Color;
 import android.os.Handler;
 import android.os.Message;
@@ -156,6 +157,11 @@ public class SampleAdPlayer extends LinearLayout implements PlayerInterface,
     if (getParent() != null) {
       ((ViewGroup) getParent()).removeView(this);
     }
+  }
+
+  @Override
+  public void configurationChanged(Configuration newConfig) {
+    // TODO Auto-generated method stub
   }
 
   @Override

--- a/VRSampleApp/app/src/main/java/com/ooyala/sample/screen/VideoFragment.java
+++ b/VRSampleApp/app/src/main/java/com/ooyala/sample/screen/VideoFragment.java
@@ -1,5 +1,6 @@
 package com.ooyala.sample.screen;
 
+import android.content.res.Configuration;
 import android.os.Bundle;
 import android.support.annotation.NonNull;
 import android.support.annotation.Nullable;
@@ -131,6 +132,14 @@ public class VideoFragment extends Fragment implements Observer, DefaultHardware
       }
     }
     changeToolbarVisibilityInFullscreenMode(arg);
+  }
+
+  @Override
+  public void onConfigurationChanged(Configuration newConfig) {
+    super.onConfigurationChanged(newConfig);
+    if (player != null) {
+      player.configurationChanged(newConfig);
+    }
   }
 
   public void applyADSManager(OoyalaSkinLayout skinLayout) {

--- a/VRSampleAppKotlin/app/src/main/java/com/ooyala/sample/screen/VideoFragment.kt
+++ b/VRSampleAppKotlin/app/src/main/java/com/ooyala/sample/screen/VideoFragment.kt
@@ -2,6 +2,7 @@ package com.ooyala.sample
 
 import android.Manifest.permission.WRITE_EXTERNAL_STORAGE
 import android.content.pm.PackageManager.PERMISSION_GRANTED
+import android.content.res.Configuration
 import android.os.Bundle
 import android.support.v4.app.Fragment
 import android.support.v4.content.ContextCompat
@@ -96,6 +97,11 @@ open class VideoFragment() : Fragment(), Observer, DefaultHardwareBackBtnHandler
       }
       initPlayer()
     }
+  }
+
+  override fun onConfigurationChanged(newConfig: Configuration?) {
+    super.onConfigurationChanged(newConfig)
+    player?.configurationChanged(newConfig)
   }
 
   override fun update(o: Observable?, arg: Any?) {


### PR DESCRIPTION
Update samples according to the LifeCycleInterface changes. VR samples: call player.configurationChanged

Here is a description:
Using Google VR Services 1.12 the world displays correctly, however once I update a phone to 1.13 (tested on Pixel 1, Pixel 2, and an S8) the world shifts into what looks like portrait mode and Looking vertically around the world will move horizontally (and vice versa).
Link to the issue here: https://github.com/googlevr/gvr-android-sdk/issues/536

For VRSampleApp and VRSampleAppKotlin we avoid restarting activity when orientation changes on Android to meet customer expectations while using VR 360 content. So I used onConfigurationChanged callback to get round this problem.