### PR TITLE
[PLAYER-3408] Multi audio: audio tracks order is the same for all the platforms. 

### DIFF
--- a/OoyalaSkinSampleApp/app/src/main/java/com/ooyala/sample/players/MultiAudioActivity.java
+++ b/OoyalaSkinSampleApp/app/src/main/java/com/ooyala/sample/players/MultiAudioActivity.java
@@ -15,8 +15,8 @@ import com.ooyala.android.player.exoplayer.multiaudio.AudioTrack;
 import com.ooyala.android.skin.OoyalaSkinLayoutController;
 import com.ooyala.sample.R;
 
+import java.util.List;
 import java.util.Observable;
-import java.util.Set;
 
 /**
  * This activity illustrates how you can use multi audio methods
@@ -25,7 +25,7 @@ public class MultiAudioActivity extends AbstractHookActivity {
   private static final String TAG = MultiAudioActivity.class.getSimpleName();
 
   private AudioTrack currentAudioTrack;
-  private Set<AudioTrack> audioTracks;
+  private List<AudioTrack> audioTracks;
 
   @Override
   public void onCreate(Bundle savedInstanceState) {


### PR DESCRIPTION
I replaced unordered Set on List to keep audio tracks in ordered sequence of elements.