### PR TITLE
[PLAYER-3980] UnbundledPlayerActivity: observe STREAM_PARAMS_UPDATED_…

### DIFF
--- a/AdvancedPlaybackSampleApp/app/src/main/java/com/ooyala/sample/players/UnbundledPlayerActivity.java
+++ b/AdvancedPlaybackSampleApp/app/src/main/java/com/ooyala/sample/players/UnbundledPlayerActivity.java
@@ -69,9 +69,10 @@ public class UnbundledPlayerActivity extends AbstractHookActivity {
       int combinedBitrate = stream.getCombinedBitrate();
       int width = stream.getWidth();
       int height = stream.getHeight();
+      String url = stream.getUrl();
       String streamParams = String.format("Stream params: video bitrate: %d, audio bitrate: %d, " +
-        "combined bitrate: %d, width: %d, height: %d", videoBitrate, audioBitrate, combinedBitrate,
-        width, height);
+        "combined bitrate: %d, width: %d, height: %d, URL: %s", videoBitrate, audioBitrate,
+        combinedBitrate, width, height, url);
       Log.d(TAG, streamParams);
     }
   }


### PR DESCRIPTION
…NOTIFICATION_NAME to obtain Stream params for a remote asset.

This is a fix for remote assets. Customers will be able to get relevant `Stream` params (video bitrate, audio bitrate, combined bitrate, width, height) from ExoPlayer. I changed the sample to explain when the params are ready to retrieve from `OoyalaPlayer`.