### PR TITLE
[PLAYER-3816] OoyalaIMA manager should be initialized after embed code has been set up

### DIFF
--- a/CompleteSampleApp/app/src/main/java/com/ooyala/sample/players/CustomConfiguredIMAPlayerActivity.java
+++ b/CompleteSampleApp/app/src/main/java/com/ooyala/sample/players/CustomConfiguredIMAPlayerActivity.java
@@ -36,12 +36,12 @@ public class CustomConfiguredIMAPlayerActivity extends AbstractHookActivity {
 			OoyalaPlayerLayout playerLayout = (OoyalaPlayerLayout) findViewById(R.id.ooyalaPlayer);
 			optimizedOoyalaPlayerLayoutController = new OptimizedOoyalaPlayerLayoutController(playerLayout, player);
 
+			player.setEmbedCode(EMBED_CODE);
+
 			/** DITA_START:<ph id="ima_custom"> **/
 			//OoyalaIMAManager imaManager = new OoyalaIMAManager(player);
 
 			/** DITA_END:</ph> **/
-
-			player.setEmbedCode(EMBED_CODE);
 		}
 	}
 }

--- a/CompleteSampleApp/app/src/main/java/com/ooyala/sample/players/PreconfiguredIMAPlayerActivity.java
+++ b/CompleteSampleApp/app/src/main/java/com/ooyala/sample/players/PreconfiguredIMAPlayerActivity.java
@@ -49,10 +49,10 @@ public class PreconfiguredIMAPlayerActivity extends AbstractHookActivity {
 
       optimizedOoyalaPlayerLayoutController = new OptimizedOoyalaPlayerLayoutController(playerLayout, player);
 
+      player.setEmbedCode(EMBED_CODE);
+
       @SuppressWarnings("unused")
       OoyalaIMAManager imaManager = new OoyalaIMAManager(player);
-
-      player.setEmbedCode(EMBED_CODE);
     }
   }
 }

--- a/ExoPlayerSampleApp/app/src/main/java/com/ooyala/sample/players/PreconfiguredIMAPlayerActivity.java
+++ b/ExoPlayerSampleApp/app/src/main/java/com/ooyala/sample/players/PreconfiguredIMAPlayerActivity.java
@@ -48,12 +48,12 @@ public class PreconfiguredIMAPlayerActivity extends AbstractHookActivity {
       playerLayoutController.addObserver(this);
       player.addObserver(this);
 
-      @SuppressWarnings("unused")
-      OoyalaIMAManager imaManager = new OoyalaIMAManager(player, skinLayout);
-
       if (player.setEmbedCode(embedCode)) {
         //player.play();
       }
+
+      @SuppressWarnings("unused")
+      OoyalaIMAManager imaManager = new OoyalaIMAManager(player, skinLayout);
     }
   }
 

--- a/IMASampleApp/app/src/main/java/com/ooyala/sample/players/CustomConfiguredIMAPlayerActivity.java
+++ b/IMASampleApp/app/src/main/java/com/ooyala/sample/players/CustomConfiguredIMAPlayerActivity.java
@@ -36,12 +36,12 @@ public class CustomConfiguredIMAPlayerActivity extends AbstractHookActivity {
 			OoyalaPlayerLayout playerLayout = (OoyalaPlayerLayout) findViewById(R.id.ooyalaPlayer);
 			playerLayoutController = new OptimizedOoyalaPlayerLayoutController(playerLayout, player);
 
+			player.setEmbedCode(embedCode);
+
 			/** DITA_START:<ph id="ima_custom"> **/
 			//OoyalaIMAManager imaManager = new OoyalaIMAManager(player);
 
 			/** DITA_END:</ph> **/
-
-			player.setEmbedCode(embedCode);
 		}
 	}
 }

--- a/IMASampleApp/app/src/main/java/com/ooyala/sample/players/PreconfiguredIMAPlayerActivity.java
+++ b/IMASampleApp/app/src/main/java/com/ooyala/sample/players/PreconfiguredIMAPlayerActivity.java
@@ -49,10 +49,10 @@ public class PreconfiguredIMAPlayerActivity extends AbstractHookActivity {
 
       playerLayoutController = new OptimizedOoyalaPlayerLayoutController(playerLayout, player);
 
+      player.setEmbedCode(embedCode);
+
       @SuppressWarnings("unused")
       OoyalaIMAManager imaManager = new OoyalaIMAManager(player);
-
-      player.setEmbedCode(embedCode);
     }
   }
 }

--- a/OoyalaSkinSampleApp/app/src/main/java/com/ooyala/sample/players/CustomConfiguredIMAPlayerActivity.java
+++ b/OoyalaSkinSampleApp/app/src/main/java/com/ooyala/sample/players/CustomConfiguredIMAPlayerActivity.java
@@ -62,6 +62,10 @@ public class CustomConfiguredIMAPlayerActivity extends AbstractHookActivity
 
     player.addObserver(this);
 
+    if (player.setEmbedCode(embedCode)) {
+//      player.play();
+    }
+
     /** DITA_START:<ph id="ima_custom"> **/
 
     OoyalaIMAManager imaManager = new OoyalaIMAManager(player, skinLayout);
@@ -74,10 +78,6 @@ public class CustomConfiguredIMAPlayerActivity extends AbstractHookActivity
     imaManager.setAdUrlOverride("http://pubads.g.doubleclick.net/gampad/ads?sz=640x480&iu=/7521029/pb_test_mid&ciu_szs=640x480&impl=s&cmsid=949&vid=FjbGRjbzp0DV_5-NtXBVo5Rgp3Sj0R5C&gdfp_req=1&env=vp&output=xml_vast2&unviewed_position_start=1&url=[referrer_url]&description_url=[description_url]&correlator=[timestamp]");
     // imaManager.setAdTagParameters(null);
     /** DITA_END:</ph> **/
-
-    if (player.setEmbedCode(embedCode)) {
-//      player.play();
-    }
   }
 
   @Override

--- a/OoyalaSkinSampleApp/app/src/main/java/com/ooyala/sample/players/MultiAudioActivity.java
+++ b/OoyalaSkinSampleApp/app/src/main/java/com/ooyala/sample/players/MultiAudioActivity.java
@@ -57,11 +57,11 @@ public class MultiAudioActivity extends AbstractHookActivity {
       playerLayoutController.addObserver(this);
       player.addObserver(this);
 
-      OoyalaIMAManager imaManager = new OoyalaIMAManager(player, skinLayout);
-
       if (!player.setEmbedCode(embedCode)) {
         Log.e(TAG, "Asset Failure");
       }
+
+      OoyalaIMAManager imaManager = new OoyalaIMAManager(player, skinLayout);
 
       // Show how to set audio settings i.e. default audio language
       //setAudioSettings();

--- a/OoyalaSkinSampleApp/app/src/main/java/com/ooyala/sample/players/PreconfiguredIMAPlayerActivity.java
+++ b/OoyalaSkinSampleApp/app/src/main/java/com/ooyala/sample/players/PreconfiguredIMAPlayerActivity.java
@@ -64,17 +64,17 @@ public class PreconfiguredIMAPlayerActivity extends AbstractHookActivity
 
 			player.addObserver(this);
 
+			if (player.setEmbedCode(embedCode)) {
+				if(autoPlay)
+					player.play();
+			}
+
 			@SuppressWarnings("unused")
 			OoyalaIMAManager imaManager = new OoyalaIMAManager(player, skinLayout);
 			imaManager.setOnAdErrorListener(this);
 			imaManager.setOnAdEventListener(this);
 			imaManager.setAdsLoadedListener(this);
 			imaManager.setContainerUpdatedListener(this);
-
-			if (player.setEmbedCode(embedCode)) {
-				if(autoPlay)
-					player.play();
-			}
 		}
 	}
 

--- a/PlaybackLab/MavenSampleApp/app/src/main/java/com/ooyala/sample/players/MavenPlayerActivity.java
+++ b/PlaybackLab/MavenSampleApp/app/src/main/java/com/ooyala/sample/players/MavenPlayerActivity.java
@@ -62,9 +62,6 @@ public class MavenPlayerActivity extends Activity implements Observer {
 
     player.addObserver(this);
 
-    @SuppressWarnings("unused")
-    OoyalaIMAManager imaManager = new OoyalaIMAManager(player, skinLayout);
-
     if (player.setEmbedCode(EMBED)) {
       //Uncomment for Auto-Play
       //player.play();
@@ -72,6 +69,9 @@ public class MavenPlayerActivity extends Activity implements Observer {
     else {
       Log.e(TAG, "Asset Failure");
     }
+
+    @SuppressWarnings("unused")
+    OoyalaIMAManager imaManager = new OoyalaIMAManager(player, skinLayout);
   }
 
   @Override

--- a/VRSampleApp/app/src/main/java/com/ooyala/sample/screen/VideoFragment.java
+++ b/VRSampleApp/app/src/main/java/com/ooyala/sample/screen/VideoFragment.java
@@ -180,9 +180,9 @@ public class VideoFragment extends Fragment implements Observer, DefaultHardware
     playerController = new OoyalaSkinLayoutController(getActivity().getApplication(), skinLayout, player, skinOptions);
     playerController.addObserver(this);
 
-    applyADSManager(skinLayout);
-
     player.setEmbedCode(embedCode);
+
+    applyADSManager(skinLayout);
   }
 
   @Override

--- a/VRSampleAppKotlin/app/src/main/java/com/ooyala/sample/screen/VideoFragment.kt
+++ b/VRSampleAppKotlin/app/src/main/java/com/ooyala/sample/screen/VideoFragment.kt
@@ -149,9 +149,9 @@ open class VideoFragment() : Fragment(), Observer, DefaultHardwareBackBtnHandler
     playerController = OoyalaSkinLayoutController(activity!!.application, playerSkinLayout, player, skinOptions)
     playerController?.addObserver(this)
 
-    initAdManager()
-
     player?.embedCode = embedCode
+
+    initAdManager()
   }
 
   override fun invokeDefaultOnBackPressed() {


### PR DESCRIPTION
_Issue description_
In `fetchCuePoint()` method, `_player.getDuration()` returns 1 instead of a real duration, because `player` hasn't completely initialized yet.

_Solution_
Set `embed code` before OoyalaIMA manager initialization.