### PR TITLE
[PLAYER-4329] Revert previous fix

### DIFF
--- a/OoyalaSkinSampleApp/app/src/main/java/com/ooyala/sample/players/AbstractHookActivity.java
+++ b/OoyalaSkinSampleApp/app/src/main/java/com/ooyala/sample/players/AbstractHookActivity.java
@@ -84,7 +84,7 @@ public abstract class AbstractHookActivity extends Activity implements Observer,
 		super.onStop();
 		Log.d(TAG, "Player Activity Stopped");
 		if (null != player) {
-			player.release();
+			player.suspend();
 		}
 	}
 


### PR DESCRIPTION
Reverting the logic on what to do when onStop() on an Activity is called. We continue using suspend instead of release. Release clears the current player info and it cannot resume when we resume the Activity.

Also this fixes PLAYER-4353 and PLAYER-4354