### PR TITLE
[PLAYER-4789] fix for Player error:null” error is displayed when VR36…

### DIFF
--- a/VRSampleApp/app/src/main/AndroidManifest.xml
+++ b/VRSampleApp/app/src/main/AndroidManifest.xml
@@ -19,7 +19,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:theme="@style/AppTheme"
-        tools:replace="android:icon">
+        tools:replace="android:icon"
+        android:usesCleartextTraffic="true">
         <meta-data
             android:name="com.google.android.gms.version"
             android:value="@integer/google_play_services_version" />

--- a/VRSampleAppKotlin/app/src/main/AndroidManifest.xml
+++ b/VRSampleAppKotlin/app/src/main/AndroidManifest.xml
@@ -16,7 +16,8 @@
         android:label="@string/app_name"
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
-        android:theme="@style/AppTheme">
+        android:theme="@style/AppTheme"
+        android:usesCleartextTraffic="true">
         <meta-data
             android:name="com.google.android.gms.version"
             android:value="@integer/google_play_services_version" />


### PR DESCRIPTION
Starting with Android 9.0 (API level 28), cleartext support is disabled by default. Made it enabled for VRSample Apps.