### PR TITLE
[PLAYER-4800] Added FOREGROUND_SERVICE permission for Android 9

### DIFF
--- a/ChromecastSampleApp/app/src/main/AndroidManifest.xml
+++ b/ChromecastSampleApp/app/src/main/AndroidManifest.xml
@@ -5,6 +5,7 @@
     <uses-permission android:name="android.permission.ACCESS_WIFI_STATE" />
     <uses-permission android:name="android.permission.ACCESS_NETWORK_STATE"/>
     <uses-permission android:name="android.permission.WRITE_EXTERNAL_STORAGE"/>
+    <uses-permission android:name="android.permission.FOREGROUND_SERVICE" />
 
     <application
         android:allowBackup="true"


### PR DESCRIPTION
According this document https://developer.android.com/about/versions/pie/android-9.0-migration#tya :
Apps wanting to use foreground services must now request the FOREGROUND_SERVICE permission first. This is a normal permission, so the system automatically grants it to the requesting app. Starting a foreground service without the permission throws a SecurityException. 