### PR TITLE
[PLAYER-4807] Applyed fix for OptionSampleApp and OoyalaSkinApp also

### DIFF
--- a/FreewheelSampleApp/app/src/main/AndroidManifest.xml
+++ b/FreewheelSampleApp/app/src/main/AndroidManifest.xml
@@ -13,7 +13,8 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/Theme.AppCompat">
+        android:theme="@style/Theme.AppCompat"
+        android:usesCleartextTraffic="true">
 
         <uses-library android:name="org.apache.http.legacy" android:required="false" />
         
@@ -21,7 +22,7 @@
             android:name="com.ooyala.sample.lists.FreewheelListActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/app_name" >
-                        <intent-filter>
+            <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>

--- a/OoyalaSkinSampleApp/app/src/main/AndroidManifest.xml
+++ b/OoyalaSkinSampleApp/app/src/main/AndroidManifest.xml
@@ -15,7 +15,10 @@
         android:largeHeap="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/Theme.AppCompat">
+        android:theme="@style/Theme.AppCompat"
+        android:usesCleartextTraffic="true">
+
+        <uses-library android:name="org.apache.http.legacy" android:required="false" />
 
         <service android:name="com.adobe.adobepass.accessenabler.api.AccessEnablerService"
                  android:label="AccessEnabler service"/>

--- a/OptionsSampleApp/app/src/main/AndroidManifest.xml
+++ b/OptionsSampleApp/app/src/main/AndroidManifest.xml
@@ -13,8 +13,11 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/Theme.AppCompat">
-        
+        android:theme="@style/Theme.AppCompat"
+        android:usesCleartextTraffic="true">
+
+        <uses-library android:name="org.apache.http.legacy" android:required="false" />
+
         <activity
             android:name="com.ooyala.sample.lists.OptionsListActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"


### PR DESCRIPTION
Updating android manifests for OptionSampleApp and  OoyalaSkinApp according that link :
https://developers.google.com/maps/documentation/android-sdk/config#specify_requirement_for_apache_http_legacy_library
Also updating manifests for "Cleartext HTTP traffic not permitted" on Android 9
