### PR TITLE
[PLAYER-4813] Fixed cast view behavior

### DIFF
--- a/ChromecastSampleApp/app/src/main/java/com/ooyala/sample/ChromecastPlayerActivity.java
+++ b/ChromecastSampleApp/app/src/main/java/com/ooyala/sample/ChromecastPlayerActivity.java
@@ -48,6 +48,7 @@ public class ChromecastPlayerActivity extends AppCompatActivity implements Obser
   private String secondEmbedCode;
   private String pcode;
   private String domain;
+  private boolean wasInCastMode;
 
   // Write the sdk events text along with events count to log file in sdcard if the log file already exists
   private SDCardLogcatOoyalaEventsLogger playbackLog = new SDCardLogcatOoyalaEventsLogger();
@@ -79,6 +80,10 @@ public class ChromecastPlayerActivity extends AppCompatActivity implements Obser
     super.onResume();
     if (player != null) {
       player.resume();
+      if (!player.isInCastMode() && wasInCastMode) {
+        castManager.hideCastView();
+        wasInCastMode = false;
+      }
     }
   }
 
@@ -159,8 +164,13 @@ public class ChromecastPlayerActivity extends AppCompatActivity implements Obser
 
     if (arg1 == OoyalaPlayer.STATE_CHANGED_NOTIFICATION_NAME) {
       if (player.isInCastMode()) {
+        if (!wasInCastMode) {
+          wasInCastMode = true;
+        }
         OoyalaPlayer.State state = player.getState();
         castViewManager.updateCastState(this, state);
+      } else if (wasInCastMode) {
+        wasInCastMode = false;
       }
     }
 


### PR DESCRIPTION
There are two request:

1. First one (https://git.corp.ooyala.com/projects/PBA/repos/android-sdk/pull-requests/555/overview). 
Need to make hideCastView() public because we need to call it from Activity's onResume() callback.
hideCastView() is called internally, connected to google's cast library callbacks when we disconnect from chromecast.
But in onStop() we can't remove the view without an exception, so it stays not removed.

2. Logic to clean the view if needed in activity (this)