### PR TITLE
[PLAYER-4828] Fix for http url of VAST AD

### DIFF
--- a/AdvancedPlaybackSampleApp/app/src/main/AndroidManifest.xml
+++ b/AdvancedPlaybackSampleApp/app/src/main/AndroidManifest.xml
@@ -13,7 +13,8 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/Theme.AppCompat">
+        android:theme="@style/Theme.AppCompat"
+        android:usesCleartextTraffic="true">
         
         <activity
             android:name="com.ooyala.sample.lists.AdvancedPlaybackListActivity"

--- a/AdvancedPlaybackSampleApp/app/src/main/java/com/ooyala/sample/players/InsertAdPlayerActivity.java
+++ b/AdvancedPlaybackSampleApp/app/src/main/java/com/ooyala/sample/players/InsertAdPlayerActivity.java
@@ -46,6 +46,7 @@ public class InsertAdPlayerActivity extends AbstractHookActivity {
 			Options options = new Options.Builder().setUseExoPlayer(true).build();
 			player = new OoyalaPlayer(pcode, new PlayerDomain(domain), options);
 			playerLayoutController = new OoyalaPlayerLayoutController(playerLayout, player);
+			player.enableSSL(false);
 			player.addObserver(this);
 
 			//  Set up performance monitoring to watch standard events and ads events.


### PR DESCRIPTION
Enabled http requests in Manifest file. Due url https://xd-team.ooyala.com.s3.amazonaws.com/ads/Advert%20Vast%20Preroll.mp4 used as VAST AD in a example have not correct certificate, set 
player.enableSSL(false)