### PR TITLE
[PLAYER-4828] [PLAYER-4832] Fixed regression from PLAYER-4818, updated CompleteSamp…  …leApp with Android 9 fixes

### DIFF
--- a/AdvancedPlaybackSampleApp/app/src/main/AndroidManifest.xml
+++ b/AdvancedPlaybackSampleApp/app/src/main/AndroidManifest.xml
@@ -13,7 +13,8 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/Theme.AppCompat">
+        android:theme="@style/Theme.AppCompat"
+        android:usesCleartextTraffic="true">
         
         <activity
             android:name="com.ooyala.sample.lists.AdvancedPlaybackListActivity"

--- a/AdvancedPlaybackSampleApp/app/src/main/java/com/ooyala/sample/players/InsertAdPlayerActivity.java
+++ b/AdvancedPlaybackSampleApp/app/src/main/java/com/ooyala/sample/players/InsertAdPlayerActivity.java
@@ -46,6 +46,7 @@ public class InsertAdPlayerActivity extends AbstractHookActivity {
 			Options options = new Options.Builder().setUseExoPlayer(true).build();
 			player = new OoyalaPlayer(pcode, new PlayerDomain(domain), options);
 			playerLayoutController = new OoyalaPlayerLayoutController(playerLayout, player);
+			player.enableSSL(false);
 			player.addObserver(this);
 
 			//  Set up performance monitoring to watch standard events and ads events.

--- a/AdvancedPlaybackSampleApp/app/src/main/java/com/ooyala/sample/utils/AbstractDefaultOoyalaPlayerControls.java
+++ b/AdvancedPlaybackSampleApp/app/src/main/java/com/ooyala/sample/utils/AbstractDefaultOoyalaPlayerControls.java
@@ -226,6 +226,11 @@ public abstract class AbstractDefaultOoyalaPlayerControls implements OoyalaPlaye
     }
   }
 
+  @Override
+  public void refresh() {
+
+  }
+
   protected abstract void updateButtonStates();
 
   protected abstract void setupControls();

--- a/AdvancedPlaybackSampleApp/app/src/main/java/com/ooyala/sample/utils/CustomOverlay.java
+++ b/AdvancedPlaybackSampleApp/app/src/main/java/com/ooyala/sample/utils/CustomOverlay.java
@@ -93,4 +93,10 @@ public class CustomOverlay extends TextView implements OoyalaPlayerControls {
   public void update(Observable observable, Object o) {
 
   }
+
+  @Override
+  public void refresh() {
+    
+  }
+
 }

--- a/CompleteSampleApp/app/src/main/AndroidManifest.xml
+++ b/CompleteSampleApp/app/src/main/AndroidManifest.xml
@@ -13,7 +13,10 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/Theme.AppCompat">
+        android:theme="@style/Theme.AppCompat"
+        android:usesCleartextTraffic="true">
+
+        <uses-library android:name="org.apache.http.legacy" android:required="false" />
 
         <service android:name="com.adobe.adobepass.accessenabler.api.AccessEnablerService"
                  android:label="AccessEnabler service"/>

--- a/CompleteSampleApp/app/src/main/java/com/ooyala/sample/players/InsertAdPlayerActivity.java
+++ b/CompleteSampleApp/app/src/main/java/com/ooyala/sample/players/InsertAdPlayerActivity.java
@@ -46,6 +46,7 @@ public class InsertAdPlayerActivity extends AbstractHookActivity {
 			Options options = new Options.Builder().setUseExoPlayer(true).build();
 			player = new OoyalaPlayer(PCODE, new PlayerDomain(DOMAIN), options);
 			playerLayoutController = new OoyalaPlayerLayoutController(playerLayout, player);
+			player.enableSSL(false);
 			player.addObserver(this);
 
 			//  Set up performance monitoring to watch standard events and ads events.

--- a/CompleteSampleApp/app/src/main/java/com/ooyala/sample/utils/AbstractDefaultOoyalaPlayerControls.java
+++ b/CompleteSampleApp/app/src/main/java/com/ooyala/sample/utils/AbstractDefaultOoyalaPlayerControls.java
@@ -226,6 +226,11 @@ public abstract class AbstractDefaultOoyalaPlayerControls implements OoyalaPlaye
     }
   }
 
+  @Override
+  public void refresh() {
+
+  }
+
   protected abstract void updateButtonStates();
 
   protected abstract void setupControls();

--- a/CompleteSampleApp/app/src/main/java/com/ooyala/sample/utils/CustomOverlay.java
+++ b/CompleteSampleApp/app/src/main/java/com/ooyala/sample/utils/CustomOverlay.java
@@ -91,6 +91,11 @@ public class CustomOverlay extends AppCompatTextView implements OoyalaPlayerCont
   }
 
   @Override
+  public void refresh() {
+
+  }
+
+  @Override
   public void update(Observable observable, Object o) {
 
   }


### PR DESCRIPTION
This fixing PLAYER-4828 (Both AdvancedSampleApp and CompleteSampeApp->Advanced)
Enabled http requests in Manifest file. Due url https://xd-team.ooyala.com.s3.amazonaws.com/ads/Advert%20Vast%20Preroll.mp4 used as VAST AD in a example have not correct certificate, set
player.enableSSL(false)
Also this fixing regression from PLAYER-4818 (PLAYER-4832 ticket)