### PR TITLE
Player-4830 CompleteSampleApp Crash Fix

### DIFF
--- a/CompleteSampleApp/app/src/main/AndroidManifest.xml
+++ b/CompleteSampleApp/app/src/main/AndroidManifest.xml
@@ -180,6 +180,9 @@
         <activity android:name=".players.ProgrammaticVolumePlayerActivity"
           android:configChanges="keyboardHidden|orientation|screenSize">
         </activity>
+        <activity android:name=".players.CustomActivity"
+            android:configChanges="keyboardHidden|orientation|screenSize">
+        </activity>
 
         <meta-data
             android:name="com.google.android.gms.version"

--- a/CompleteSampleApp/app/src/main/java/com/ooyala/sample/players/OoyalaPlayerTokenPlayerActivity.java
+++ b/CompleteSampleApp/app/src/main/java/com/ooyala/sample/players/OoyalaPlayerTokenPlayerActivity.java
@@ -43,7 +43,7 @@ public class OoyalaPlayerTokenPlayerActivity extends Activity implements Observe
   String PCODE = null;
   String DOMAIN = null;
   private final String ACCOUNT_ID = "accountID";
-  Boolean AUTOPLAY = false;
+  private boolean AUTOPLAY = false;
 
   /*
    * The API Key and Secret should not be saved inside your applciation (even in git!).

--- a/CompleteSampleApp/app/src/main/java/com/ooyala/sample/players/OoyalaPlayerTokenPlayerActivity.java
+++ b/CompleteSampleApp/app/src/main/java/com/ooyala/sample/players/OoyalaPlayerTokenPlayerActivity.java
@@ -43,7 +43,7 @@ public class OoyalaPlayerTokenPlayerActivity extends Activity implements Observe
   String PCODE = null;
   String DOMAIN = null;
   private final String ACCOUNT_ID = "accountID";
-  Boolean autoPlay = false;
+  Boolean AUTOPLAY = false;
 
   /*
    * The API Key and Secret should not be saved inside your applciation (even in git!).
@@ -66,7 +66,7 @@ public class OoyalaPlayerTokenPlayerActivity extends Activity implements Observe
     EMBED = getIntent().getExtras().getString("embed_code");
     PCODE = getIntent().getExtras().getString("pcode");
     DOMAIN = getIntent().getExtras().getString("domain");
-    autoPlay = getIntent().getExtras().getBoolean("autoPlay");
+    AUTOPLAY = getIntent().getExtras().getBoolean("autoPlay");
 
     //Initialize the player
     OoyalaPlayerLayout playerLayout = (OoyalaPlayerLayout) findViewById(R.id.ooyalaPlayer);
@@ -78,7 +78,7 @@ public class OoyalaPlayerTokenPlayerActivity extends Activity implements Observe
     player.addObserver(this);
 
     if (player.setEmbedCode(EMBED)) {
-      if(autoPlay) {
+      if(AUTOPLAY) {
         player.play();
       }
     }

--- a/CompleteSampleApp/app/src/main/java/com/ooyala/sample/players/OoyalaPlayerTokenPlayerActivity.java
+++ b/CompleteSampleApp/app/src/main/java/com/ooyala/sample/players/OoyalaPlayerTokenPlayerActivity.java
@@ -43,6 +43,7 @@ public class OoyalaPlayerTokenPlayerActivity extends Activity implements Observe
   String PCODE = null;
   String DOMAIN = null;
   private final String ACCOUNT_ID = "accountID";
+  Boolean autoPlay = false;
 
   /*
    * The API Key and Secret should not be saved inside your applciation (even in git!).
@@ -65,6 +66,7 @@ public class OoyalaPlayerTokenPlayerActivity extends Activity implements Observe
     EMBED = getIntent().getExtras().getString("embed_code");
     PCODE = getIntent().getExtras().getString("pcode");
     DOMAIN = getIntent().getExtras().getString("domain");
+    autoPlay = getIntent().getExtras().getBoolean("autoPlay");
 
     //Initialize the player
     OoyalaPlayerLayout playerLayout = (OoyalaPlayerLayout) findViewById(R.id.ooyalaPlayer);
@@ -76,7 +78,9 @@ public class OoyalaPlayerTokenPlayerActivity extends Activity implements Observe
     player.addObserver(this);
 
     if (player.setEmbedCode(EMBED)) {
-      player.play();
+      if(autoPlay) {
+        player.play();
+      }
     }
     else {
       Log.e(TAG, "Asset Failure");


### PR DESCRIPTION
Player-4830 Fixed CompleteSampleApp crash issue on selecting "Asset Options".  Added "CustomActivity" to AndroidManifest.xml.
Also Fixed AUTOPLAY. Now works as per selection. 