### PR TITLE
[PLAYER-4905] BasicPlaybackSampleApp: android:usesCleartextTraffic is added

### DIFF
--- a/BasicPlaybackSampleApp/app/src/main/AndroidManifest.xml
+++ b/BasicPlaybackSampleApp/app/src/main/AndroidManifest.xml
@@ -12,7 +12,8 @@
         android:allowBackup="true"
         android:icon="@drawable/ic_launcher"
         android:label="@string/app_name"
-        android:theme="@style/Theme.AppCompat">
+        android:theme="@style/Theme.AppCompat"
+        android:usesCleartextTraffic="true">
         
         <activity
             android:name="com.ooyala.sample.lists.BasicPlaybackListActivity"


### PR DESCRIPTION
Enabled http requests in Manifest file. 

However according to an acceptance criteria from https://jira.corp.ooyala.com/browse/PLAYER-4325 for devices Android 9+:
_OoyalaPlayer.enableSSL(true) have all communications from the SDK use SSL_

So **VAST2 Ad Wrapper** asset URL http://xd-team.ooyala.com.s3.amazonaws.com/ads/Advert%20Vast%20Preroll.mp4 is converted to https://xd-team.ooyala.com.s3.amazonaws.com/ads/Advert%20Vast%20Preroll.mp4 but there is no correct SSL certificate for the URL.