### PR TITLE
[PLAYER-4945] Changes in resizable player update logic

### DIFF
--- a/OoyalaSkinSampleApp/app/src/main/AndroidManifest.xml
+++ b/OoyalaSkinSampleApp/app/src/main/AndroidManifest.xml
@@ -46,7 +46,7 @@
             android:name=".lists.IMAListActivity"
             android:configChanges="keyboardHidden|orientation|screenSize" >
         </activity>
-        
+
         <activity android:name=".players.PreconfiguredIMAPlayerActivity"
             android:configChanges="keyboardHidden|orientation|screenSize">
         </activity>
@@ -60,7 +60,8 @@
         </activity>
 
         <activity android:name=".players.ResizablePlayerActivity"
-                  android:configChanges="keyboardHidden|orientation|screenSize">
+                  android:configChanges="keyboardHidden|orientation|screenSize"
+                  android:theme="@style/Theme.AppCompat.NoActionBar">
         </activity>
         <activity android:name=".players.AssetActivity"
                   android:configChanges="keyboardHidden|orientation|screenSize">

--- a/OoyalaSkinSampleApp/app/src/main/java/com/ooyala/sample/players/ResizablePlayerActivity.java
+++ b/OoyalaSkinSampleApp/app/src/main/java/com/ooyala/sample/players/ResizablePlayerActivity.java
@@ -1,19 +1,26 @@
 package com.ooyala.sample.players;
 
+import android.content.res.Configuration;
 import android.os.Bundle;
-import androidx.appcompat.app.AppCompatActivity;
 import android.view.Menu;
 import android.view.MenuInflater;
 import android.view.MenuItem;
-
+import android.view.View;
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.ooyala.sample.R;
 import com.ooyala.sample.utils.fragments.SkinPlayerFragment;
 
-public class ResizablePlayerActivity extends AppCompatActivity implements DefaultHardwareBackBtnHandler {
+public class ResizablePlayerActivity extends AppCompatActivity implements DefaultHardwareBackBtnHandler, View.OnSystemUiVisibilityChangeListener {
 
   private static String name = "Resizable Skin Player";
   private SkinPlayerFragment skinPlayerFragment;
+  private Toolbar toolbar;
+  private boolean fullscreen;
+  private int lastMenuItemId = UNSET_ID;
+  private static final int FULLSCREEN = 6;
+  public static final int UNSET_ID = -1;
 
   public static String getName() {
     return name;
@@ -22,9 +29,17 @@ public class ResizablePlayerActivity extends AppCompatActivity implements Defaul
   @Override
   protected void onCreate(Bundle savedInstanceState) {
     super.onCreate(savedInstanceState);
-    getSupportActionBar().setDisplayShowTitleEnabled(false);
     setContentView(R.layout.configurable_player_skin_layout);
     skinPlayerFragment = (SkinPlayerFragment) getSupportFragmentManager().findFragmentById(R.id.video_fragment);
+    toolbar = findViewById(R.id.toolbar);
+
+    // need to use Toolbar instead of ActionBar because of a bug
+    // after toggling setSystemUiVisibility
+    setSupportActionBar(toolbar);
+    getSupportActionBar().setDisplayShowTitleEnabled(false);
+
+    final View decorView = getWindow().getDecorView();
+    decorView.setOnSystemUiVisibilityChangeListener(this);
   }
 
   @Override
@@ -41,7 +56,32 @@ public class ResizablePlayerActivity extends AppCompatActivity implements Defaul
 
   @Override
   public boolean onOptionsItemSelected(MenuItem item) {
-    skinPlayerFragment.resizePlayer(item.getItemId());
+    lastMenuItemId = item.getItemId();
+    skinPlayerFragment.resizePlayer(lastMenuItemId, getSupportActionBar().getHeight(), fullscreen);
     return super.onOptionsItemSelected(item);
+  }
+
+  @Override
+  public void onConfigurationChanged(Configuration newConfig) {
+    super.onConfigurationChanged(newConfig);
+
+    skinPlayerFragment.resizePlayer(lastMenuItemId, getSupportActionBar().getHeight(), fullscreen);
+  }
+
+  @Override
+  public void onSystemUiVisibilityChange(int visibility) {
+    fullscreen = visibility == FULLSCREEN;
+
+    setViewVisibility(toolbar, fullscreen);
+
+    skinPlayerFragment.resizePlayer(lastMenuItemId, getSupportActionBar().getHeight(), fullscreen);
+  }
+
+  private void setViewVisibility(View view, boolean fullscreen) {
+    if (fullscreen && view.getVisibility() == View.VISIBLE) {
+      view.setVisibility(View.GONE);
+    } else if (!fullscreen && view.getVisibility() == View.GONE) {
+      view.setVisibility(View.VISIBLE);
+    }
   }
 }

--- a/OoyalaSkinSampleApp/app/src/main/java/com/ooyala/sample/utils/fragments/SkinPlayerFragment.java
+++ b/OoyalaSkinSampleApp/app/src/main/java/com/ooyala/sample/utils/fragments/SkinPlayerFragment.java
@@ -2,17 +2,11 @@ package com.ooyala.sample.utils.fragments;
 
 import android.graphics.Point;
 import android.os.Bundle;
+import android.util.Log;
+import android.view.*;
+import android.widget.RelativeLayout;
 import androidx.annotation.Nullable;
 import androidx.fragment.app.Fragment;
-import android.util.Log;
-import android.view.Display;
-import android.view.LayoutInflater;
-import android.view.Menu;
-import android.view.MenuInflater;
-import android.view.View;
-import android.view.ViewGroup;
-import android.widget.RelativeLayout;
-
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.ooyala.android.OoyalaNotification;
 import com.ooyala.android.OoyalaPlayer;
@@ -26,18 +20,18 @@ import com.ooyala.sample.R;
 import java.util.Observable;
 import java.util.Observer;
 
+import static com.ooyala.sample.players.ResizablePlayerActivity.UNSET_ID;
+
 public class SkinPlayerFragment extends Fragment implements Observer, DefaultHardwareBackBtnHandler {
   private static final String EMBED = "JiOTdrdzqAujYa5qvnOxszbrTEuU5HMt";
   final String TAG = this.getClass().toString();
 
-  final String PCODE  = "c0cTkxOqALQviQIGAHWY5hP0q9gU";
+  final String PCODE = "c0cTkxOqALQviQIGAHWY5hP0q9gU";
   final String DOMAIN = "http://ooyala.com";
 
   private OoyalaPlayer player;
   private OoyalaSkinLayout skinLayout;
   OoyalaSkinLayoutController controller;
-
-
 
   @Nullable
   @Override
@@ -45,7 +39,7 @@ public class SkinPlayerFragment extends Fragment implements Observer, DefaultHar
     View view = inflater.inflate(R.layout.configurable_skin_fragment, container, false);
 
     // Get the SkinLayout from our layout xml
-    skinLayout = (OoyalaSkinLayout)view.findViewById(R.id.ooyalaSkin);
+    skinLayout = view.findViewById(R.id.ooyalaSkin);
 
     // Create the OoyalaPlayer, with some built-in UI disabled
     PlayerDomain domain = new PlayerDomain(DOMAIN);
@@ -61,8 +55,7 @@ public class SkinPlayerFragment extends Fragment implements Observer, DefaultHar
     if (player.setEmbedCode(EMBED)) {
       //Uncomment for autoplay
       //player.play();
-    }
-    else {
+    } else {
       Log.e(TAG, "Asset Failure");
     }
     return view;
@@ -72,28 +65,71 @@ public class SkinPlayerFragment extends Fragment implements Observer, DefaultHar
   public void onCreateOptionsMenu(Menu menu, MenuInflater inflater) {
     inflater.inflate(R.menu.skin_menu, menu);
   }
-  
-  public void resizePlayer(int type) {
+
+  public void resizePlayer(int type, int toolbarHeight, boolean fullscreen) {
     Display display = getActivity().getWindowManager().getDefaultDisplay();
     Point size = new Point();
     display.getSize(size);
     int width = size.x;
     int height = size.y;
 
+    RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(width, height);
+
     switch (type) {
       case R.id.action_wide:
-        height = height / 2;
+        updateParamsWide(params, height);
         break;
       case R.id.action_tall:
-        width = width / 2;
+        updateParamsTall(params, width, height, toolbarHeight, fullscreen);
         break;
       case R.id.action_fill:
-        width = ViewGroup.LayoutParams.MATCH_PARENT;
-        height = ViewGroup.LayoutParams.MATCH_PARENT;
+        updateParamsFill(params, height, toolbarHeight, fullscreen);
+        break;
+      case UNSET_ID:
+        updateParamsDefault(params, fullscreen);
+        break;
     }
-    RelativeLayout.LayoutParams params = new RelativeLayout.LayoutParams(width, height);
-    params.addRule(RelativeLayout.CENTER_IN_PARENT, RelativeLayout.TRUE);
+
     skinLayout.setLayoutParams(params);
+  }
+
+  private void updateParamsWide(RelativeLayout.LayoutParams params, int height){
+    params.height = height / 2;
+    params.addRule(RelativeLayout.CENTER_IN_PARENT, RelativeLayout.TRUE);
+  }
+
+  private void updateParamsTall(RelativeLayout.LayoutParams params, int width, int height, int toolbarHeight, boolean fullscreen) {
+    params.width = width / 2;
+    if (fullscreen) {
+      params.height = ViewGroup.LayoutParams.MATCH_PARENT;
+      params.addRule(RelativeLayout.CENTER_IN_PARENT, RelativeLayout.TRUE);
+    } else {
+      params.height = height - toolbarHeight;
+      params.addRule(RelativeLayout.CENTER_HORIZONTAL, RelativeLayout.TRUE);
+      params.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM, RelativeLayout.TRUE);
+    }
+  }
+
+  private void updateParamsFill(RelativeLayout.LayoutParams params, int height, int toolbarHeight, boolean fullscreen) {
+    params.width = ViewGroup.LayoutParams.MATCH_PARENT;
+    if (fullscreen) {
+      params.height = ViewGroup.LayoutParams.MATCH_PARENT;
+    } else {
+      params.height = height - toolbarHeight;
+      params.addRule(RelativeLayout.ALIGN_PARENT_BOTTOM, RelativeLayout.TRUE);
+    }
+    params.addRule(RelativeLayout.CENTER_IN_PARENT, RelativeLayout.TRUE);
+  }
+
+  private void updateParamsDefault(RelativeLayout.LayoutParams params, boolean fullscreen) {
+    if (fullscreen) {
+      params.width = ViewGroup.LayoutParams.MATCH_PARENT;
+      params.height = ViewGroup.LayoutParams.MATCH_PARENT;
+    } else {
+      params.width = skinLayout.getSourceWidth();
+      params.height = skinLayout.getSourceHeight();
+    }
+    params.addRule(RelativeLayout.CENTER_IN_PARENT, RelativeLayout.TRUE);
   }
 
   @Override
@@ -107,12 +143,12 @@ public class SkinPlayerFragment extends Fragment implements Observer, DefaultHar
       player.suspend();
     }
   }
-  
+
   @Override
   public void onResume() {
     super.onResume();
     if (controller != null) {
-      controller.onResume( getActivity(), this );
+      controller.onResume(getActivity(), this);
     }
     Log.d(TAG, "Player Fragment Restarted");
     if (player != null) {
@@ -130,7 +166,7 @@ public class SkinPlayerFragment extends Fragment implements Observer, DefaultHar
     final String arg1 = OoyalaNotification.getNameOrUnknown(argN);
 
     if (arg1 == OoyalaSkinLayoutController.FULLSCREEN_CHANGED_NOTIFICATION_NAME) {
-      Log.d(TAG, "Fullscreen Notification received : " + arg1 + " - fullScreen: " + ((OoyalaNotification)argN).getData());
+      Log.d(TAG, "Fullscreen Notification received : " + arg1 + " - fullScreen: " + ((OoyalaNotification) argN).getData());
     }
   }
 }

--- a/OoyalaSkinSampleApp/app/src/main/res/layout/configurable_player_skin_layout.xml
+++ b/OoyalaSkinSampleApp/app/src/main/res/layout/configurable_player_skin_layout.xml
@@ -5,6 +5,12 @@
     android:layout_gravity="center_horizontal|bottom"
     android:orientation="vertical" >
 
+    <androidx.appcompat.widget.Toolbar
+            android:id="@+id/toolbar"
+            android:background="#212121"
+            android:layout_width="match_parent"
+            android:layout_height="wrap_content"/>
+
     <fragment android:name="com.ooyala.sample.utils.fragments.SkinPlayerFragment"
               android:id="@+id/video_fragment"
               android:layout_width="match_parent"

--- a/OoyalaSkinSampleApp/app/src/main/res/layout/configurable_skin_fragment.xml
+++ b/OoyalaSkinSampleApp/app/src/main/res/layout/configurable_skin_fragment.xml
@@ -1,17 +1,19 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-              android:id="@+id/controlsLayout"
-              android:layout_width="fill_parent"
-              android:layout_height="fill_parent"
-              android:layout_gravity="center"
-              android:orientation="vertical" >
+                xmlns:custom="http://schemas.android.com/apk/res-auto"
+                android:id="@+id/controlsLayout"
+                android:layout_width="fill_parent"
+                android:layout_height="fill_parent"
+                android:layout_gravity="center"
+                android:orientation="vertical">
 
     <com.ooyala.android.skin.OoyalaSkinLayout
         android:id="@+id/ooyalaSkin"
         android:layout_width="300dp"
         android:layout_height="300dp"
         android:layout_centerInParent="true"
-        android:background="#000">
+        android:background="#000"
+        custom:resizableLayout="true">
     </com.ooyala.android.skin.OoyalaSkinLayout>
 
     <TextView

--- a/OoyalaSkinSampleApp/app/src/main/res/values/attrs.xml
+++ b/OoyalaSkinSampleApp/app/src/main/res/values/attrs.xml
@@ -1,0 +1,6 @@
+<?xml version="1.0" encoding="utf-8"?>
+<resources>
+    <declare-styleable name="OoyalaSkinLayout">
+        <attr name="resizableLayout" format="boolean" />
+    </declare-styleable>
+</resources>


### PR DESCRIPTION
https://jira.corp.ooyala.com/browse/PLAYER-4945

MERGE ONLY AFTER CANDIDATE IS MERGED IN DEV

Connected with this request https://github.com/ooyala/native-skin/pull/812

Here are fixed uncorrect sizes and behavior of resizable player.

There are much more conditions than were implemented in OoyalaSkinLayout, so some callbacks from there are disabled and handled by new logic.
Toolbar added to get rid of that bug
https://stackoverflow.com/questions/28874114/action-bar-displayed-incorrectly-when-returning-from-immersive-mode