### PR TITLE
[PLAYER-4904] DownloadSerializationActivity modernisation to check that downloading OPT assets work as expected

### DIFF
--- a/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/lists/DownloadSerializationActivity.java
+++ b/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/lists/DownloadSerializationActivity.java
@@ -5,36 +5,36 @@ import android.content.Intent;
 import android.os.Bundle;
 import android.os.Environment;
 import android.os.Handler;
-import androidx.core.app.ActivityCompat;
-import androidx.core.content.ContextCompat;
 import android.util.Log;
 import android.view.View;
 import android.view.ViewGroup;
 import android.widget.Button;
 import android.widget.LinearLayout;
 import android.widget.TextView;
+import android.widget.Toast;
 
-import com.ooyala.android.EmbedTokenGenerator;
-import com.ooyala.android.EmbedTokenGeneratorCallback;
-import com.ooyala.android.EmbeddedSecureURLGenerator;
 import com.ooyala.android.offline.DashDownloader;
 import com.ooyala.android.offline.DashOptions;
-import com.ooyala.android.util.SDCardLogcatOoyalaEventsLogger;
 import com.ooyala.sample.R;
 import com.ooyala.sample.players.OfflineSkinPlayerActivity;
+import com.ooyala.sample.utils.DownloadState;
 import com.ooyala.sample.utils.DownloadableAsset;
+import com.ooyala.sample.utils.PlayerSelectionOption;
+import com.ooyala.sample.utils.TokenGenerator;
 
 import java.io.File;
-import java.net.URL;
 import java.util.ArrayList;
-import java.util.HashMap;
 import java.util.Iterator;
 import java.util.List;
 
+import androidx.core.app.ActivityCompat;
+import androidx.core.content.ContextCompat;
+
 import static android.Manifest.permission.WRITE_EXTERNAL_STORAGE;
 import static android.content.pm.PackageManager.PERMISSION_GRANTED;
+import static com.ooyala.sample.utils.DownloadState.*;
 
-public class DownloadSerializationActivity extends Activity implements DashDownloader.Listener, EmbedTokenGenerator {
+public class DownloadSerializationActivity extends Activity implements DashDownloader.Listener {
 
     public final static String getName() {
         return "Download Serialization";
@@ -47,27 +47,9 @@ public class DownloadSerializationActivity extends Activity implements DashDownl
     //Here you can define how many simultaneous downloads can happen.
     protected  final int DOWNLOADS_ALLOWED = 3;
 
-    //Defining assets states
-    protected final int NOT_DOWNLOADED = 0;
-    protected final int DOWNLOADING = 1;
-    protected final int WAITING = 2;
-    protected final int COMPLETED = 3;
-    protected final int ERROR = 4;
-    protected final int ABORT = 5;
-
-
-    // Write the sdk events text along with events count to log file in sdcard if the log file already exists
-    SDCardLogcatOoyalaEventsLogger Playbacklog= new SDCardLogcatOoyalaEventsLogger();
-
     protected Handler handler;
     protected DashDownloader downloader;
     protected LinearLayout linearLayoutVertical;
-
-    // An account ID, if you are using Concurrent Streams or Entitlements
-    private final String ACCOUNT_ID = "";
-    private final String APIKEY = "";
-    private final String SECRET = "";
-
 
     private List<DownloadableAsset> downloadQueue;
     private List<DownloadableAsset> onHoldQueue;
@@ -84,22 +66,22 @@ public class DownloadSerializationActivity extends Activity implements DashDownl
         setContentView(R.layout.download_activity);
 
         assets = new ArrayList<>();
-        assets.add(new DownloadableAsset("HEVC", "hrODl0ZTE6X4qlmpiUGbx84nI9Uva6TE","BjcWYyOu1KK2DiKOkF41Z2k0X57l"));
-        assets.add(new DownloadableAsset("Widevine DASH", "BuY3RsMzE61s6nTC5ct6R-DOapuPt5f7","FoeG863GnBL4IhhlFC1Q2jqbkH9m"));
-        assets.add(new DownloadableAsset("Playready + DASH", "tpYTlnMzE6m4S-a1Yonj5ydnVwQXBGyI", "FoeG863GnBL4IhhlFC1Q2jqbkH9m"));
-        assets.add(new DownloadableAsset("OTS Test", "04c3IyYzE6WLNzHuPDcBrMgUsDP7nTYq", "35d4ec4fa05645289a127682acc29325"));
-        assets.add(new DownloadableAsset("Enterprise OTS Test", "hsdHIyYzE668escyHgrFiednk4831Un3", "529095912bec4ab7aefe23d6b11fdf2a"));
-        assets.add(new DownloadableAsset("Logan", "dqcGlqOTE6U2FJ8LTxvDV9P_GPzeae_G", "c7ed739d6ef43f1a13577fac2109d22"));
-        assets.add(new DownloadableAsset("Dron construction", "lvN3lpZDE604CHXxbOwswqz4daAPgDq7", "1mbWoyOuPzcGLtowbsFNlVHbepva"));
-        assets.add(new DownloadableAsset("Waves in sunset", "hqZHQ1YjE6tZiEdyKMMiY-kHlxPaFqpG", "1mbWoyOuPzcGLtowbsFNlVHbepva"));
-        assets.add(new DownloadableAsset("Sunrise", "44NHQ1YjE6YGVqOuKUkkmfqGrh2gjTBN", "1mbWoyOuPzcGLtowbsFNlVHbepva"));
-        assets.add(new DownloadableAsset("Jellyfish", "1kZHBpZDE6y90G_NyEf6-tvG6_-BWCd-", "1mbWoyOuPzcGLtowbsFNlVHbepva"));
-        assets.add(new DownloadableAsset("Decomposing doll", "lxcmI2YjE6WCVstI4M1RcaNhyujitVsO", "1mbWoyOuPzcGLtowbsFNlVHbepva"));
-        assets.add(new DownloadableAsset("Tagsgraphic", "hhY3BpZDE60HyUMUrMTU3bX0AXMBFk4y", "1mbWoyOuPzcGLtowbsFNlVHbepva"));
-        assets.add(new DownloadableAsset("Clouds", "M2Y3BpZDE6FyMp_xQEaL_ZPwNOXQnQXL", "1mbWoyOuPzcGLtowbsFNlVHbepva"));
-        assets.add(new DownloadableAsset("Swimming", "QyY3BpZDE6pBgGxV4OCGykDKBbj6ZuMs", "1mbWoyOuPzcGLtowbsFNlVHbepva"));
-        assets.add(new DownloadableAsset("Butterfly", "N4YnBpZDE6P7EIno_y74X9GNhQdJQABt", "1mbWoyOuPzcGLtowbsFNlVHbepva"));
-        assets.add(new DownloadableAsset("Big Buck Bunny ", "ljNDE2YzE6KTFgw7hfC6IeXZJ_UBlVSK", "1mbWoyOuPzcGLtowbsFNlVHbepva"));
+        assets.add(new DownloadableAsset("HEVC", new PlayerSelectionOption("hrODl0ZTE6X4qlmpiUGbx84nI9Uva6TE", "BjcWYyOu1KK2DiKOkF41Z2k0X57l", DOMAIN, OfflineSkinPlayerActivity.class)));
+        assets.add(new DownloadableAsset("Widevine DASH", new PlayerSelectionOption("BuY3RsMzE61s6nTC5ct6R-DOapuPt5f7", "FoeG863GnBL4IhhlFC1Q2jqbkH9m", DOMAIN, OfflineSkinPlayerActivity.class)));
+        assets.add(new DownloadableAsset("Playready + DASH", new PlayerSelectionOption("tpYTlnMzE6m4S-a1Yonj5ydnVwQXBGyI", "FoeG863GnBL4IhhlFC1Q2jqbkH9m", DOMAIN, OfflineSkinPlayerActivity.class)));
+        assets.add(new DownloadableAsset("OTS Test", new PlayerSelectionOption("04c3IyYzE6WLNzHuPDcBrMgUsDP7nTYq", "35d4ec4fa05645289a127682acc29325", DOMAIN, OfflineSkinPlayerActivity.class)));
+        assets.add(new DownloadableAsset("Enterprise OTS Test", new PlayerSelectionOption("hsdHIyYzE668escyHgrFiednk4831Un3", "529095912bec4ab7aefe23d6b11fdf2a", DOMAIN, OfflineSkinPlayerActivity.class)));
+        assets.add(new DownloadableAsset("Logan", new PlayerSelectionOption("dqcGlqOTE6U2FJ8LTxvDV9P_GPzeae_G", "c7ed739d6ef43f1a13577fac2109d22", DOMAIN, OfflineSkinPlayerActivity.class)));
+        assets.add(new DownloadableAsset("Dron construction", new PlayerSelectionOption("lvN3lpZDE604CHXxbOwswqz4daAPgDq7", "1mbWoyOuPzcGLtowbsFNlVHbepva", DOMAIN, OfflineSkinPlayerActivity.class)));
+        assets.add(new DownloadableAsset("Waves in sunset", new PlayerSelectionOption("hqZHQ1YjE6tZiEdyKMMiY-kHlxPaFqpG", "1mbWoyOuPzcGLtowbsFNlVHbepva", DOMAIN, OfflineSkinPlayerActivity.class)));
+        assets.add(new DownloadableAsset("Sunrise", new PlayerSelectionOption("44NHQ1YjE6YGVqOuKUkkmfqGrh2gjTBN", "1mbWoyOuPzcGLtowbsFNlVHbepva", DOMAIN, OfflineSkinPlayerActivity.class)));
+        assets.add(new DownloadableAsset("Jellyfish", new PlayerSelectionOption("1kZHBpZDE6y90G_NyEf6-tvG6_-BWCd-", "1mbWoyOuPzcGLtowbsFNlVHbepva", DOMAIN, OfflineSkinPlayerActivity.class)));
+        assets.add(new DownloadableAsset("Decomposing doll", new PlayerSelectionOption("lxcmI2YjE6WCVstI4M1RcaNhyujitVsO", "1mbWoyOuPzcGLtowbsFNlVHbepva", DOMAIN, OfflineSkinPlayerActivity.class)));
+        assets.add(new DownloadableAsset("Tagsgraphic", new PlayerSelectionOption("hhY3BpZDE60HyUMUrMTU3bX0AXMBFk4y", "1mbWoyOuPzcGLtowbsFNlVHbepva", DOMAIN, OfflineSkinPlayerActivity.class)));
+        assets.add(new DownloadableAsset("Clouds", new PlayerSelectionOption("M2Y3BpZDE6FyMp_xQEaL_ZPwNOXQnQXL", "1mbWoyOuPzcGLtowbsFNlVHbepva", DOMAIN, OfflineSkinPlayerActivity.class)));
+        assets.add(new DownloadableAsset("Swimming", new PlayerSelectionOption("QyY3BpZDE6pBgGxV4OCGykDKBbj6ZuMs", "1mbWoyOuPzcGLtowbsFNlVHbepva", DOMAIN, OfflineSkinPlayerActivity.class)));
+        assets.add(new DownloadableAsset("Butterfly", new PlayerSelectionOption("N4YnBpZDE6P7EIno_y74X9GNhQdJQABt", "1mbWoyOuPzcGLtowbsFNlVHbepva", DOMAIN, OfflineSkinPlayerActivity.class)));
+        assets.add(new DownloadableAsset("Big Buck Bunny ", new PlayerSelectionOption("ljNDE2YzE6KTFgw7hfC6IeXZJ_UBlVSK", "1mbWoyOuPzcGLtowbsFNlVHbepva", DOMAIN, OfflineSkinPlayerActivity.class)));
 
         handler = new Handler(getMainLooper());
 
@@ -113,33 +95,35 @@ public class DownloadSerializationActivity extends Activity implements DashDownl
         linearLayoutVertical = findViewById(R.id.linearLayoutVertical);
 
         //Adding items to linearLayout
-        for (final DownloadableAsset a : assets) {
+        for (final DownloadableAsset asset : assets) {
+            final PlayerSelectionOption option = asset.getPlayerSelectionOption();
+
             LinearLayout linearLayout = new LinearLayout(this);
 
             //Displaying asset name
             TextView itemText = new TextView(this);
-            itemText.setText(a.getName());
+            itemText.setText(asset.getName());
             itemText.setOnClickListener(new View.OnClickListener() {
                 @Override
                 public void onClick(View view) {
                     //Launch an offline player with selected embed code
-                    Intent intent = new Intent(DownloadSerializationActivity.this, OfflineSkinPlayerActivity.class);
+                    Intent intent = new Intent(DownloadSerializationActivity.this, option.getActivity());
                     intent.setFlags(Intent.FLAG_ACTIVITY_REORDER_TO_FRONT);
-                    intent.putExtra("embed_code", a.getEmbedCode());
-                    intent.putExtra("pcode", a.getpCode());
-                    intent.putExtra("domain", DOMAIN);
-                    intent.putExtra("selection_name", a.getName());
+                    intent.putExtra("embed_code", option.getEmbedCode());
+                    intent.putExtra("pcode", option.getPcode());
+                    intent.putExtra("domain", option.getDomain());
+                    intent.putExtra("selection_name", asset.getName());
                     startActivity(intent);
                 }
             });
-            LinearLayout.LayoutParams textParams = new LinearLayout.LayoutParams(700, ViewGroup.LayoutParams.WRAP_CONTENT,0.9F);
+            LinearLayout.LayoutParams textParams = new LinearLayout.LayoutParams(700, ViewGroup.LayoutParams.WRAP_CONTENT, 0.9F);
             linearLayout.addView(itemText, 0, textParams);
 
             //This button will start an asset download
             Button startButton = new Button(this);
-            startButton.setId(a.getEmbedCode().hashCode());
+            startButton.setId(option.getEmbedCode().hashCode());
             startButton.setBackgroundResource(android.R.drawable.stat_sys_download);
-            LinearLayout.LayoutParams buttonParams = new LinearLayout.LayoutParams(120, 120,0.1F);
+            LinearLayout.LayoutParams buttonParams = new LinearLayout.LayoutParams(120, 120, 0.1F);
             linearLayout.addView(startButton, 1, buttonParams);
             startButton.setOnClickListener(new View.OnClickListener() {
                 @Override
@@ -148,31 +132,33 @@ public class DownloadSerializationActivity extends Activity implements DashDownl
                         ActivityCompat.requestPermissions(DownloadSerializationActivity.this, new String[]{WRITE_EXTERNAL_STORAGE}, PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE);
                     } else {
                         // Use this DashOptions to download an asset with OPT
-                        currentPCode = a.getpCode();
-                        DashOptions options = new DashOptions.Builder(currentPCode, a.getEmbedCode(), DOMAIN, folder).setEmbedTokenGenerator(DownloadSerializationActivity.this).build();
+                        currentPCode = option.getPcode();
+                        DashOptions options = new DashOptions.Builder(currentPCode, option.getEmbedCode(), DOMAIN, folder)
+                            .setEmbedTokenGenerator(new TokenGenerator(asset.getPlayerSelectionOption())) //new TokenGenerator(asset.getPlayerSelectionOption() //DownloadSerializationActivity.this
+                            .build();
                         downloader = new DashDownloader(DownloadSerializationActivity.this, options, DownloadSerializationActivity.this);
 
                         if (downloadQueue.size() < DOWNLOADS_ALLOWED) {
-                            downloadQueue.add(a);
+                            downloadQueue.add(asset);
                             downloader.startDownload();
-                            a.setStatus(DOWNLOADING);
-                            Log.d("Log", "Start downloading : " + a.getEmbedCode());
+                            asset.setStatus(DOWNLOADING);
+                            Log.d("Log", "Start downloading : " + option.getEmbedCode());
                             Log.d("Log", "Download queue size:" + downloadQueue.size());
                             Log.d("Log", "On hold queue size: " + onHoldQueue.size());
                         } else {
-                            onHoldQueue.add(a);
-                            a.setStatus(WAITING);
-                            Log.d("Log", "Waiting to download : " + a.getEmbedCode());
+                            onHoldQueue.add(asset);
+                            asset.setStatus(WAITING);
+                            Log.d("Log", "Waiting to download : " + option.getEmbedCode());
                             Log.d("Log", "On hold queue size: " + onHoldQueue.size());
                         }
-                        updateDownloadButton(a);
+                        updateDownloadButton(asset.getPlayerSelectionOption().getEmbedCode(), asset.getStatus());
                     }
                 }
             });
 
             linearLayoutVertical.addView(linearLayout);
             //Updating button state if asset is already downloaded in device
-            updateDownloadButton(a);
+            updateDownloadButton(asset.getPlayerSelectionOption().getEmbedCode(), asset.getStatus());
         }
 
         //This deletes all assets already downloaded
@@ -199,12 +185,13 @@ public class DownloadSerializationActivity extends Activity implements DashDownl
     protected void onResume() {
         super.onResume();
 
-        for (final DownloadableAsset a :assets) {
-            File folder = new File(android.os.Environment.getExternalStoragePublicDirectory(android.os.Environment.DIRECTORY_MOVIES), a.getEmbedCode());
+        for (final DownloadableAsset asset : assets) {
+            PlayerSelectionOption option = asset.getPlayerSelectionOption();
+            File folder = new File(android.os.Environment.getExternalStoragePublicDirectory(android.os.Environment.DIRECTORY_MOVIES), option.getEmbedCode());
             if (folder.exists() && folder.length() > 0){
-                a.setStatus(COMPLETED);
+                asset.setStatus(COMPLETED);
                 //Updating button state if asset is already downloaded in device
-                updateDownloadButton(a);
+                updateDownloadButton(asset.getPlayerSelectionOption().getEmbedCode(), asset.getStatus());
             }
         }
     }
@@ -215,17 +202,20 @@ public class DownloadSerializationActivity extends Activity implements DashDownl
     public void getNextAssetToDownload(){
         Iterator<DownloadableAsset> iterator = onHoldQueue.iterator();
         while(iterator.hasNext()){
-            DownloadableAsset a = iterator.next();
-            if (downloadQueue.size() < DOWNLOADS_ALLOWED){
-                DashOptions options = new DashOptions.Builder(a.getpCode(), a.getEmbedCode(), DOMAIN, folder).setEmbedTokenGenerator(DownloadSerializationActivity.this).build();
+            DownloadableAsset asset = iterator.next();
+            if (downloadQueue.size() < DOWNLOADS_ALLOWED) {
+                PlayerSelectionOption option = asset.getPlayerSelectionOption();
+                DashOptions options = new DashOptions.Builder(option.getPcode(), option.getEmbedCode(), DOMAIN, folder)
+                    .setEmbedTokenGenerator(new TokenGenerator(option))
+                    .build();
                 downloader = new DashDownloader(DownloadSerializationActivity.this, options, DownloadSerializationActivity.this);
                 downloader.startDownload();
-                downloadQueue.add(a);
-                a.setStatus(WAITING);
-                updateDownloadButton(a);
-                Log.d("Log","\n Downloading " + a.getName());
+                downloadQueue.add(asset);
+                asset.setStatus(WAITING);
+                updateDownloadButton(asset.getPlayerSelectionOption().getEmbedCode(), asset.getStatus());
+                Log.d("Log", "\n Downloading " + asset.getName());
                 iterator.remove();
-                Log.d("Log", "Start downloading : " + a.getEmbedCode());
+                Log.d("Log", "Start downloading : " + option.getEmbedCode());
                 Log.d("Log", "Download queue size:" + downloadQueue.size());
                 Log.d("Log","On hold queue size: " + onHoldQueue.size());
             }
@@ -234,23 +224,32 @@ public class DownloadSerializationActivity extends Activity implements DashDownl
 
     /**
      * This updates the UI buttons with the asset status
-     * @param asset downloadable asset
+     * @param embedCode downloadable embedCode asset
+     * @param status downloadable status
      */
-    public void updateDownloadButton(DownloadableAsset asset){
-        for (int i=0; i<linearLayoutVertical.getChildCount(); i++){
+    public void updateDownloadButton(String embedCode, DownloadState status) {
+        for (int i = 0; i < linearLayoutVertical.getChildCount(); i++) {
             if (linearLayoutVertical.getChildAt(i) instanceof LinearLayout){
                 LinearLayout l = (LinearLayout)linearLayoutVertical.getChildAt(i);
                 Button b = (Button) l.getChildAt(1);
-                if (b.getId() == asset.getEmbedCode().hashCode()){
-                    int status = asset.getStatus();
-                    if (status == COMPLETED ){
-                        b.setBackgroundResource(android.R.drawable.checkbox_on_background);
-                    } else if (status == WAITING || status == DOWNLOADING){
-                        b.setBackgroundResource(android.R.drawable.ic_popup_sync);
-                    } else if (status == ERROR || status == ABORT){
-                        b.setBackgroundResource(android.R.drawable.stat_notify_error);
-                    } else if (status == NOT_DOWNLOADED){
-                        b.setBackgroundResource(android.R.drawable.stat_sys_download);
+                if (b.getId() == embedCode.hashCode()) {
+                    switch (status) {
+                        case COMPLETED:
+                            b.setBackgroundResource(android.R.drawable.checkbox_on_background);
+                            break;
+                        case WAITING:
+                        case DOWNLOADING:
+                            b.setBackgroundResource(android.R.drawable.ic_popup_sync);
+                            break;
+                        case ERROR:
+                        case ABORT:
+                            b.setBackgroundResource(android.R.drawable.stat_notify_error);
+                            break;
+                        case NOT_DOWNLOADED:
+                            b.setBackgroundResource(android.R.drawable.stat_sys_download);
+                            break;
+                        default:
+                            break;
                     }
                 }
             }
@@ -261,18 +260,19 @@ public class DownloadSerializationActivity extends Activity implements DashDownl
      * This deletes all downloaded assets
      */
     public void deleteDownloadedAssets(){
-        boolean result = false;
-        for (final DownloadableAsset a :assets) {
-            File folder = new File(android.os.Environment.getExternalStoragePublicDirectory(android.os.Environment.DIRECTORY_MOVIES), a.getEmbedCode());
+        boolean result;
+        for (final DownloadableAsset asset : assets) {
+            PlayerSelectionOption option = asset.getPlayerSelectionOption();
+            File folder = new File(android.os.Environment.getExternalStoragePublicDirectory(android.os.Environment.DIRECTORY_MOVIES), option.getEmbedCode());
             if (folder.exists() && folder.isDirectory()){
                 for (File f :folder.listFiles()) {
                     result = f.delete();
-                    Log.d("Log", "Deletion of" + a.getName() + ": " + result);
+                    Log.d("Log", "Deletion of" + asset.getName() + ": " + result);
                 }
                 folder.delete();
             }
-            a.setStatus(NOT_DOWNLOADED);
-            updateDownloadButton(a);
+            asset.setStatus(NOT_DOWNLOADED);
+            updateDownloadButton(asset.getPlayerSelectionOption().getEmbedCode(), asset.getStatus());
         }
     }
 
@@ -285,7 +285,7 @@ public class DownloadSerializationActivity extends Activity implements DashDownl
                 long expiration = downloader.getLicenseExpirationDate();
                 //String expirationString = expiration == DashDownloader.INFINITE_DURATION ? "infinite" : String.valueOf(expiration);
                 Log.d("Log", getAssetNameByEmbedCode(embedCode) + " download completed!");
-                updateDownloadButton(new DownloadableAsset(embedCode, COMPLETED));
+                updateDownloadButton(embedCode, COMPLETED);
                 removeAssetByEmbedCode(embedCode,downloadQueue);
                 getNextAssetToDownload();
             }
@@ -298,7 +298,7 @@ public class DownloadSerializationActivity extends Activity implements DashDownl
             public void run() {
                 Log.d("Log", "Download aborted " + embedCode);
                 removeAssetByEmbedCode(embedCode,downloadQueue);
-                updateDownloadButton(new DownloadableAsset(embedCode, ABORT));
+                updateDownloadButton(embedCode, ABORT);
                 getNextAssetToDownload();
             }
         });
@@ -308,11 +308,14 @@ public class DownloadSerializationActivity extends Activity implements DashDownl
         handler.post(new Runnable() {
             @Override
             public void run() {
-                Log.d("Log","\n Error on " + embedCode + ": "+ ex.getLocalizedMessage());
+                String errorMessage = "Error on " + embedCode + ": "+ ex.getLocalizedMessage();
+                Log.d("Log","\n" + errorMessage);
+                Toast.makeText(DownloadSerializationActivity.this, errorMessage, Toast.LENGTH_LONG).show();
+
                 File folder = new File(android.os.Environment.getExternalStoragePublicDirectory(android.os.Environment.DIRECTORY_MOVIES), embedCode);
                 folder.delete();
                 removeAssetByEmbedCode(embedCode,downloadQueue);
-                updateDownloadButton(new DownloadableAsset(embedCode, ERROR));
+                updateDownloadButton(embedCode, ERROR);
                 getNextAssetToDownload();
             }
         });
@@ -347,8 +350,9 @@ public class DownloadSerializationActivity extends Activity implements DashDownl
     public boolean removeAssetByEmbedCode(String embedCode, List<DownloadableAsset> assetsList){
         Iterator<DownloadableAsset> iterator = assetsList.iterator();
         while (iterator.hasNext()) {
-            DownloadableAsset a = iterator.next();
-            if (a.getEmbedCode() == embedCode) {
+            DownloadableAsset asset = iterator.next();
+            PlayerSelectionOption option = asset.getPlayerSelectionOption();
+            if (option.getEmbedCode().equals(embedCode)) {
                 iterator.remove();
                 Log.d("Log", "Removed asset from : " + assetsList);
                 Log.d("Log","Queue size: " + assetsList.size());
@@ -366,37 +370,12 @@ public class DownloadSerializationActivity extends Activity implements DashDownl
     public String getAssetNameByEmbedCode(String embedCode){
         Iterator<DownloadableAsset> iterator = assets.iterator();
         while (iterator.hasNext()) {
-            DownloadableAsset a = iterator.next();
-            if (a.getEmbedCode() == embedCode) {
-                return a.getName();
+            DownloadableAsset asset = iterator.next();
+            PlayerSelectionOption option = asset.getPlayerSelectionOption();
+            if (option.getEmbedCode().equals(embedCode)) {
+                return asset.getName();
             }
         }
         return null;
-    }
-
-
-    @Override
-    public void getTokenForEmbedCodes(List<String> embedCodes, EmbedTokenGeneratorCallback callback) {
-        String embedCodesString = "";
-        for (String ec : embedCodes) {
-            if (ec.equals("")) embedCodesString += ",";
-            embedCodesString += ec;
-        }
-
-        HashMap<String, String> params = new HashMap<String, String>();
-        params.put("account_id", ACCOUNT_ID);
-
-    /* Uncommenting this will bypass all syndication rules on your asset
-       This will not work unless you have a working API Key and Secret.
-       This is one reason why you shouldn't keep the Secret in your app/source control */
-//     params.put("override_syndication_group", "override_all_synd_groups");
-
-        String uri = "/sas/embed_token/" + currentPCode + "/" + embedCodesString;
-
-        EmbeddedSecureURLGenerator urlGen = new EmbeddedSecureURLGenerator(APIKEY, SECRET);
-
-        URL tokenUrl = urlGen.secureURL("http://player.ooyala.com", uri, params);
-
-        callback.setEmbedToken(tokenUrl.toString());
     }
 }

--- a/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/utils/DownloadState.java
+++ b/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/utils/DownloadState.java
@@ -1,0 +1,10 @@
+package com.ooyala.sample.utils;
+
+public enum DownloadState {
+    NOT_DOWNLOADED,
+    DOWNLOADING,
+    WAITING,
+    COMPLETED,
+    ERROR,
+    ABORT
+}

--- a/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/utils/DownloadableAsset.java
+++ b/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/utils/DownloadableAsset.java
@@ -1,24 +1,16 @@
 package com.ooyala.sample.utils;
 
-import com.ooyala.sample.lists.DownloadSerializationActivity;
+import static com.ooyala.sample.utils.DownloadState.NOT_DOWNLOADED;
 
 public class DownloadableAsset {
 
-    private int status;
+    private DownloadState status = NOT_DOWNLOADED;
     private String name;
-    private String embedCode;
-    private String pCode;
+    private PlayerSelectionOption playerSelectionOption;
 
-    public DownloadableAsset(String embedCode, int status){
-        this.status = status;
-        this.embedCode = embedCode;
-    }
-
-    public DownloadableAsset(String name, String embedCode, String pCode){
-        this.status = 0;
+    public DownloadableAsset(String name, PlayerSelectionOption playerSelectionOption) {
         this.name = name;
-        this.embedCode = embedCode;
-        this.pCode = pCode;
+        this.playerSelectionOption = playerSelectionOption;
     }
 
     public String getName() {
@@ -29,28 +21,19 @@ public class DownloadableAsset {
         this.name = name;
     }
 
-    public String getpCode() {
-        return pCode;
-    }
-
-    public void setpCode(String pCode) {
-        this.pCode = pCode;
-    }
-
-    public int getStatus() {
+    public DownloadState getStatus() {
         return status;
     }
 
-    public void setStatus(int status) {
+    public void setStatus(DownloadState status) {
         this.status = status;
     }
 
-    public String getEmbedCode() {
-        return embedCode;
+    public PlayerSelectionOption getPlayerSelectionOption() {
+        return playerSelectionOption;
     }
 
-    public void setEmbedCode(String embedCode) {
-        this.embedCode = embedCode;
+    public void setPlayerSelectionOption(PlayerSelectionOption playerSelectionOption) {
+        this.playerSelectionOption = playerSelectionOption;
     }
-
 }

--- a/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/utils/PlayerSelectionOption.java
+++ b/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/utils/PlayerSelectionOption.java
@@ -15,7 +15,8 @@ public class PlayerSelectionOption {
   private String secretKey;
   private String accountId;
 
-  public PlayerSelectionOption(String embedCode, String pcode, String apiKey, String secretKey, String accountId, String domain, Class<? extends Activity> activity) {
+  public PlayerSelectionOption(String embedCode, String pcode, String apiKey, String secretKey,
+                               String accountId, String domain, Class<? extends Activity> activity) {
     this.embedCode = embedCode;
     this.activity = activity;
     this.pcode = pcode;
@@ -23,6 +24,13 @@ public class PlayerSelectionOption {
     this.apiKey = apiKey;
     this.secretKey = secretKey;
     this.accountId = accountId;
+  }
+
+  public PlayerSelectionOption(String embedCode, String pcode, String domain, Class<? extends Activity> activity) {
+    this.embedCode = embedCode;
+    this.activity = activity;
+    this.pcode = pcode;
+    this.domain = domain;
   }
 
   /**

--- a/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/utils/TokenGenerator.java
+++ b/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/utils/TokenGenerator.java
@@ -1,0 +1,44 @@
+package com.ooyala.sample.utils;
+
+import com.ooyala.android.EmbedTokenGenerator;
+import com.ooyala.android.EmbedTokenGeneratorCallback;
+import com.ooyala.android.EmbeddedSecureURLGenerator;
+
+import java.net.URL;
+import java.util.HashMap;
+import java.util.List;
+
+public class TokenGenerator implements EmbedTokenGenerator {
+
+    private PlayerSelectionOption playerSelectionOption;
+
+    public TokenGenerator(PlayerSelectionOption playerSelectionOption) {
+        this.playerSelectionOption = playerSelectionOption;
+    }
+
+    @Override
+    public void getTokenForEmbedCodes(List<String> embedCodes, EmbedTokenGeneratorCallback callback) {
+        String embedCodesString = "";
+        for (String ec : embedCodes) {
+            if (ec.equals("")) embedCodesString += ",";
+            embedCodesString += ec;
+        }
+
+        HashMap<String, String> params = new HashMap<String, String>();
+        params.put("account_id", playerSelectionOption.getAccountId());
+
+    /* Uncommenting this will bypass all syndication rules on your asset
+       This will not work unless you have a working API Key and Secret.
+       This is one reason why you shouldn't keep the Secret in your app/source control */
+//     params.put("override_syndication_group", "override_all_synd_groups");
+
+        String uri = "/sas/embed_token/" + playerSelectionOption.getPcode() + "/" + embedCodesString;
+
+        EmbeddedSecureURLGenerator urlGen = new EmbeddedSecureURLGenerator(playerSelectionOption.getApiKey(),
+            playerSelectionOption.getSecretKey());
+
+        URL tokenUrl = urlGen.secureURL("http://player.ooyala.com", uri, params);
+
+        callback.setEmbedToken(tokenUrl.toString());
+    }
+}


### PR DESCRIPTION
For OPT assets extended `PlayerSelectionOption` have to be used:
`assets.add(new DownloadableAsset("Asset's name", new PlayerSelectionOption("embed code", "pcode", api key, secret, account id, domain, OfflineSkinPlayerActivity.class)));`