### PR TITLE
[PLAYER-5123] Set usesCleartextTraffic to true for ChromecastSampleApp

### DIFF
--- a/ChromecastSampleApp/app/src/main/AndroidManifest.xml
+++ b/ChromecastSampleApp/app/src/main/AndroidManifest.xml
@@ -14,7 +14,8 @@
         android:roundIcon="@mipmap/ic_launcher_round"
         android:supportsRtl="true"
         android:name=".SampleApplication"
-        android:theme="@style/Theme.CastVideosTheme">
+        android:theme="@style/Theme.CastVideosTheme"
+        android:usesCleartextTraffic="true">
         <activity android:name=".ChromecastListActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />


### PR DESCRIPTION
Both assets from a ticket 
eHls V3 - szN292ZDE6UNthAqjp-wBISLkvKl3MzW
eHls V4 - 5hdWpvZjE69PnOVYwfsljABOQENgw4M-
force Exoplayer load some data over http:// protocol, that is not allowed by default on Android 9 based device, adding that permission in manifest resolve issue