### PR TITLE
[PLAYER-5278] DTO sample app: a pause message is added

### DIFF
--- a/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/players/OoyalaOfflineDownloadActivity.java
+++ b/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/players/OoyalaOfflineDownloadActivity.java
@@ -130,10 +130,12 @@ public class OoyalaOfflineDownloadActivity extends Activity implements DownloadL
 		Button pauseButton = findViewById(R.id.pause_button);
 		pauseButton.setOnClickListener(v -> {
 			handler.removeCallbacks(updateProgress);
-			float progress = Utils.clamp(downloader.getDownloadPercentage(TASK_INFO.taskId),
-					MIN_PROGRESS, MAX_PROGRESS);
-			String text = getString(R.string.paused_text, progress);
-			progressView.setText(text);
+			if (TASK_INFO != null) {
+				float progress = Utils.clamp(downloader.getDownloadPercentage(TASK_INFO.taskId),
+						MIN_PROGRESS, MAX_PROGRESS);
+				String text = getString(R.string.paused_text, progress);
+				progressView.setText(text);
+			}
 			downloader.cancel();
 		});
 

--- a/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/players/OoyalaOfflineDownloadActivity.java
+++ b/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/players/OoyalaOfflineDownloadActivity.java
@@ -123,11 +123,19 @@ public class OoyalaOfflineDownloadActivity extends Activity implements DownloadL
 						PERMISSIONS_REQUEST_WRITE_EXTERNAL_STORAGE);
 			} else {
 				downloader.startDownload();
+				handler.post(updateProgress);
 			}
 		});
 
 		Button pauseButton = findViewById(R.id.pause_button);
-		pauseButton.setOnClickListener(v -> downloader.cancel());
+		pauseButton.setOnClickListener(v -> {
+			handler.removeCallbacks(updateProgress);
+			float progress = Utils.clamp(downloader.getDownloadPercentage(TASK_INFO.taskId),
+					MIN_PROGRESS, MAX_PROGRESS);
+			String text = getString(R.string.paused_text, progress);
+			progressView.setText(text);
+			downloader.cancel();
+		});
 
 		Button deleteButton = findViewById(R.id.delete_button);
 		deleteButton.setOnClickListener(v -> {
@@ -277,5 +285,6 @@ public class OoyalaOfflineDownloadActivity extends Activity implements DownloadL
 				.build();
 		downloader.setOptions(options);
 		downloader.startDownload();
+		handler.post(updateProgress);
 	}
 }

--- a/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/players/OoyalaOfflineDownloadActivity.java
+++ b/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/players/OoyalaOfflineDownloadActivity.java
@@ -139,8 +139,12 @@ public class OoyalaOfflineDownloadActivity extends Activity implements DownloadL
 
 		Button deleteButton = findViewById(R.id.delete_button);
 		deleteButton.setOnClickListener(v -> {
+			if (TASK_INFO == null) {
+				progressView.setText(R.string.deletion_completed_text);
+				return;
+			}
 			downloader.cancel();
-			downloader.delete();
+			downloader.delete(TASK_INFO.taskId);
 		});
 
 		Button requestButton = findViewById(R.id.request_bitrate_and_start_button);
@@ -228,7 +232,7 @@ public class OoyalaOfflineDownloadActivity extends Activity implements DownloadL
 	}
 
 	private void onDeletion(final boolean success) {
-		handler.post(() -> progressView.setText(success ? " Deletion completed" : "Deletion failed"));
+		handler.post(() -> progressView.setText(success ? R.string.deletion_completed_text : R.string.deletion_failed_text));
 	}
 
 	@Override

--- a/PlaybackLab/DownloadToOwnSampleApp/app/src/main/res/values/strings.xml
+++ b/PlaybackLab/DownloadToOwnSampleApp/app/src/main/res/values/strings.xml
@@ -14,5 +14,7 @@
     <string name="paused_text">Paused: %.2f %%</string>
     <string name="retry_text">Downloaded percentage: %.2f. Retrying to download ..</string>
     <string name="error_text">Error: %s</string>
+    <string name="deletion_completed_text">Deletion completed</string>
+    <string name="deletion_failed_text">Deletion failed</string>
     <string name="download_description">Download</string>
 </resources>

--- a/PlaybackLab/DownloadToOwnSampleApp/app/src/main/res/values/strings.xml
+++ b/PlaybackLab/DownloadToOwnSampleApp/app/src/main/res/values/strings.xml
@@ -11,6 +11,7 @@
     <string name="progress_text">Progress: %.2f %%</string>
     <string name="completed_text">Completed</string>
     <string name="canceled_text">Canceled</string>
+    <string name="paused_text">Paused: %.2f %%</string>
     <string name="retry_text">Downloaded percentage: %.2f. Retrying to download ..</string>
     <string name="error_text">Error: %s</string>
     <string name="download_description">Download</string>


### PR DESCRIPTION
When `pause` button has been clicked while downloading, the text in the following format shows up:
"Paused: ##.##%"
For `delete` button, the text below will show up:
"Deletion completed" in the success case.
"Deletion failed" if something went wrong.
