### PR TITLE
[PLAYER-5293] Bitrate selection dialog: set choice mode single

### DIFF
--- a/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/players/OoyalaOfflineDownloadActivity.java
+++ b/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/players/OoyalaOfflineDownloadActivity.java
@@ -223,7 +223,7 @@ public class OoyalaOfflineDownloadActivity extends Activity implements DownloadL
 		bitrateTitles.addAll(bitrates.keySet());
 
 		bitrateList = dialogView.findViewById(R.id.bitrate_list);
-		bitrateList.setChoiceMode(ListView.CHOICE_MODE_MULTIPLE);
+		bitrateList.setChoiceMode(ListView.CHOICE_MODE_SINGLE);
 		bitrateList.setAdapter(bitrateTitles);
 
 		if (!bitrates.isEmpty()) {


### PR DESCRIPTION
The dialog with radio buttons, so only a single choice is required.