### PR TITLE
[PLAYER-5306] Audio Only HLS Player: null pointer exception is fixed 

### DIFF
--- a/AdvancedPlaybackSampleApp/app/src/main/java/com/ooyala/sample/players/AudioOnlyPlayerActivity.java
+++ b/AdvancedPlaybackSampleApp/app/src/main/java/com/ooyala/sample/players/AudioOnlyPlayerActivity.java
@@ -1,14 +1,16 @@
 package com.ooyala.sample.players;
 
 import android.os.Bundle;
-import androidx.annotation.Nullable;
 import android.util.Log;
+
 import com.ooyala.android.OoyalaPlayer;
 import com.ooyala.android.OoyalaPlayerLayout;
 import com.ooyala.android.PlayerDomain;
 import com.ooyala.android.configuration.Options;
 import com.ooyala.android.ui.OoyalaPlayerLayoutController;
 import com.ooyala.sample.R;
+
+import androidx.annotation.Nullable;
 
 public class AudioOnlyPlayerActivity extends AbstractHookActivity {
 
@@ -34,9 +36,10 @@ public class AudioOnlyPlayerActivity extends AbstractHookActivity {
       player = new OoyalaPlayer(pcode, new PlayerDomain(domain), createPlayerOptions());
       playerLayoutController = new OoyalaPlayerLayoutController(playerLayout, player);
       player.addObserver(this);
+
+      if (!player.setEmbedCode(embedCode))
+        Log.e(TAG, "Asset Failure");
     }
-    if (!player.setEmbedCode(embedCode))
-      Log.e(TAG, "Asset Failure");
   }
 
   private Options createPlayerOptions() {


### PR DESCRIPTION
Issue description: [AdvancedPlaybackSampleApp][Audio Only HLS Player] App crash if we try to play “Audio Only HLS Player” asset first.

