### PR TITLE
[PLAYER-5273] ExoPlayer ver is changed to 2.9.3 due to HLS multi audio errors

### DIFF
--- a/AdvancedPlaybackSampleApp/build.gradle
+++ b/AdvancedPlaybackSampleApp/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         javaVersion = JavaVersion.VERSION_1_8
 
         // App dependencies
-        exoplayerVersion = '2.9.5'
+        exoplayerVersion = '2.9.3'
         hamcrestVersion = '1.3'
         injectVersion = '1'
         jacksonVersion = '2.2.3'

--- a/BasicPlaybackSampleApp/build.gradle
+++ b/BasicPlaybackSampleApp/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         javaVersion = JavaVersion.VERSION_1_8
 
         // App dependencies
-        exoplayerVersion = '2.9.5'
+        exoplayerVersion = '2.9.3'
         injectVersion = '1'
         jacksonVersion = '2.2.3'
         junitVersion = '4.12'

--- a/ChromecastSampleApp/build.gradle
+++ b/ChromecastSampleApp/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         javaVersion = JavaVersion.VERSION_1_8
 
         // App dependencies
-        exoplayerVersion = '2.9.5'
+        exoplayerVersion = '2.9.3'
         hamcrestVersion = '1.3'
         injectVersion = '1'
         jacksonVersion = '2.2.3'

--- a/CompleteSampleApp/build.gradle
+++ b/CompleteSampleApp/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         javaVersion = JavaVersion.VERSION_1_8
 
         // App dependencies
-        exoplayerVersion = '2.9.5'
+        exoplayerVersion = '2.9.3'
         hamcrestVersion = '1.3'
         jacksonVersion = '2.2.3'
         junitVersion = '4.12'

--- a/ContentProtectionSampleApp/build.gradle
+++ b/ContentProtectionSampleApp/build.gradle
@@ -12,7 +12,7 @@ buildscript {
         gradleVersion = '3.2.1'
 
         // App dependencies
-        exoplayerVersion = '2.9.5'
+        exoplayerVersion = '2.9.3'
         gsonVersion = '2.8.5'
         supportLibraryVersion = '1.0.0'
 

--- a/ExoPlayerSampleApp/build.gradle
+++ b/ExoPlayerSampleApp/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         javaVersion = JavaVersion.VERSION_1_8
 
         // App dependencies
-        exoplayerVersion = '2.9.5'
+        exoplayerVersion = '2.9.3'
         hamcrestVersion = '1.3'
         injectVersion = '1'
         jacksonVersion = '2.2.3'

--- a/FreewheelSampleApp/build.gradle
+++ b/FreewheelSampleApp/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         javaVersion = JavaVersion.VERSION_1_8
 
         // App dependencies
-        exoplayerVersion = '2.9.5'
+        exoplayerVersion = '2.9.3'
         hamcrestVersion = '1.3'
         jacksonVersion = '2.2.3'
         junitVersion = '4.12'

--- a/HeartbeatSampleApp/build.gradle
+++ b/HeartbeatSampleApp/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         javaVersion = JavaVersion.VERSION_1_8
 
         // App dependencies
-        exoplayerVersion = '2.9.5'
+        exoplayerVersion = '2.9.3'
         supportLibraryVersion = '1.0.0'
         volleyVersion = '1.1.1'
 

--- a/IMASampleApp/build.gradle
+++ b/IMASampleApp/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         javaVersion = JavaVersion.VERSION_1_8
 
         // App dependencies
-        exoplayerVersion = '2.9.5'
+        exoplayerVersion = '2.9.3'
         injectVersion = '1'
         jacksonVersion = '2.2.3'
         junitVersion = '4.12'

--- a/NPAWSampleApp/build.gradle
+++ b/NPAWSampleApp/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         javaVersion = JavaVersion.VERSION_1_8
 
         // App dependencies
-        exoplayerVersion = '2.9.5'
+        exoplayerVersion = '2.9.3'
         injectVersion = '1'
         jacksonVersion = '2.2.3'
         junitVersion = '4.12'

--- a/NielsenSampleApp/app/build.gradle
+++ b/NielsenSampleApp/app/build.gradle
@@ -75,7 +75,7 @@ repositories {
 dependencies {
 
     implementation 'com.google.android.gms:play-services-ads:15.0.1'
-    implementation 'com.google.android.exoplayer:exoplayer:2.9.5'
+    implementation 'com.google.android.exoplayer:exoplayer:2.9.3'
     implementation files('libs/OoyalaNielsenSDK.jar')
     implementation files('libs/OoyalaSDK.aar')
     implementation files('libs/OoyalaSkinSDK.aar')

--- a/OoyalaAPISampleApp/build.gradle
+++ b/OoyalaAPISampleApp/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         javaVersion = JavaVersion.VERSION_1_8
 
         // App dependencies
-        exoplayerVersion = '2.9.5'
+        exoplayerVersion = '2.9.3'
         supportLibraryVersion = '1.0.0'
 
         // Google Play Services

--- a/OoyalaSkinSampleApp/build.gradle
+++ b/OoyalaSkinSampleApp/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         javaVersion = JavaVersion.VERSION_1_8
 
         // App dependencies
-        exoplayerVersion = '2.9.5'
+        exoplayerVersion = '2.9.3'
         gsonVersion = '2.8.5'
         hamcrestVersion = '1.3'
         injectVersion = '1'

--- a/OptionsSampleApp/build.gradle
+++ b/OptionsSampleApp/build.gradle
@@ -9,7 +9,7 @@ buildscript {
         javaVersion = JavaVersion.VERSION_1_8
 
         // App dependencies
-        exoplayerVersion = '2.9.5'
+        exoplayerVersion = '2.9.3'
         injectVersion = '1'
         jacksonVersion = '2.2.3'
         junitVersion = '4.12'

--- a/PlaybackLab/DownloadToOwnSampleApp/build.gradle
+++ b/PlaybackLab/DownloadToOwnSampleApp/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 
         // App dependencies
         constraintLayoutVersion = '1.1.3'
-        exoplayerVersion = '2.9.5'
+        exoplayerVersion = '2.9.3'
         hamcrestVersion = '1.3'
         injectVersion = '1'
         jacksonVersion = '2.2.3'

--- a/PlaybackLab/FullscreenSampleApp/build.gradle
+++ b/PlaybackLab/FullscreenSampleApp/build.gradle
@@ -11,7 +11,7 @@ buildscript {
 
         // App dependencies
         constraintLayoutVersion = '1.1.3'
-        exoplayerVersion = '2.9.5'
+        exoplayerVersion = '2.9.3'
         hamcrestVersion = '1.3'
         injectVersion = '1'
         jacksonVersion = '2.2.3'

--- a/PlaybackLab/ManUntdScrubberSampleApp/app/build.gradle
+++ b/PlaybackLab/ManUntdScrubberSampleApp/app/build.gradle
@@ -81,7 +81,7 @@ dependencies {
     implementation(group:'com.facebook', name:'react-native', version:'0.55.4', ext:'aar')
 
 
-    implementation 'com.google.android.exoplayer:exoplayer:2.9.5'
+    implementation 'com.google.android.exoplayer:exoplayer:2.9.3'
 
     implementation 'com.facebook.fresco:fresco:1.3.0'
     implementation 'com.facebook.fresco:imagepipeline-okhttp3:1.3.0'

--- a/PulseSampleApp/build.gradle
+++ b/PulseSampleApp/build.gradle
@@ -10,7 +10,7 @@ buildscript {
 
         // App dependencies
         espressoVersion = '3.1.0'
-        exoplayerVersion = '2.9.5'
+        exoplayerVersion = '2.9.3'
         gsonVersion = '2.8.5'
         hamcrestVersion = '1.3'
         injectVersion = '1'

--- a/VRSampleApp/build.gradle
+++ b/VRSampleApp/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         javaVersion = JavaVersion.VERSION_1_8
 
         // App dependencies
-        exoplayerVersion = '2.9.5'
+        exoplayerVersion = '2.9.3'
         gsonVersion = '2.8.2'
         hamcrestVersion = '1.3'
         injectVersion = '1'

--- a/VRSampleAppKotlin/build.gradle
+++ b/VRSampleAppKotlin/build.gradle
@@ -10,7 +10,7 @@ buildscript {
         javaVersion = JavaVersion.VERSION_1_8
 
         // App dependencies
-        exoplayerVersion = '2.9.5'
+        exoplayerVersion = '2.9.3'
         gsonVersion = '2.8.2'
         hamcrestVersion = '1.3'
         injectVersion = '1'

--- a/build.gradle
+++ b/build.gradle
@@ -11,7 +11,7 @@ buildscript {
         // App dependencies
         constraintLayoutVersion = '1.1.3'
         espressoVersion = '3.1.0'
-        exoplayerVersion = '2.9.5'
+        exoplayerVersion = '2.9.3'
         gsonVersion = '2.8.5'
         hamcrestVersion = '1.3'
         injectVersion = '1'


### PR DESCRIPTION
Multiple Audio tracks are not displayed for selection for some of HLS MultiAudio assets.
The issue is not seen with ExoPlayer ver 2.9.3. Since 2.9.3 the issue is reproducible in ExoPlayer demo and in our codebase. 
I'll create a ticket in ExoPlayer GitHub to track the issue.