### PR TITLE
[PLAYER-5443] Add support for direct URL support for OoyalaDownloader

### DIFF
--- a/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/DemoApplication.java
+++ b/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/DemoApplication.java
@@ -3,7 +3,11 @@ package com.ooyala.sample;
 import android.content.Context;
 
 import com.google.android.exoplayer2.upstream.cache.Cache;
+import com.ooyala.android.offline.TaskInfo;
 import com.ooyala.android.offline.VideoCache;
+
+import java.util.HashMap;
+import java.util.Map;
 
 import androidx.multidex.MultiDex;
 import androidx.multidex.MultiDexApplication;
@@ -12,9 +16,18 @@ import androidx.multidex.MultiDexApplication;
  */
 public class DemoApplication extends MultiDexApplication {
 	private static final String DOWNLOAD_CONTENT_DIRECTORY = "downloads";
+	private static Map<String, TaskInfo> DOWNLOAD_TASKS = new HashMap<>();
 
 	public synchronized Cache getDownloadCache() {
 		return VideoCache.getInstance(this, DOWNLOAD_CONTENT_DIRECTORY);
+	}
+
+	public void addDownloadTask(String embedCode, TaskInfo info) {
+		DOWNLOAD_TASKS.put(embedCode, info);
+	}
+
+	public TaskInfo retrieveCurrentTaskInfo(String embedCode) {
+		return DOWNLOAD_TASKS.get(embedCode);
 	}
 
 	@Override

--- a/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/DemoApplication.java
+++ b/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/DemoApplication.java
@@ -26,6 +26,10 @@ public class DemoApplication extends MultiDexApplication {
 		DOWNLOAD_TASKS.put(embedCode, info);
 	}
 
+	public void removeDownloadTask(String embedCode) {
+		DOWNLOAD_TASKS.remove(embedCode);
+	}
+
 	public TaskInfo retrieveCurrentTaskInfo(String embedCode) {
 		return DOWNLOAD_TASKS.get(embedCode);
 	}

--- a/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/lists/BasicPlaybackListActivity.java
+++ b/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/lists/BasicPlaybackListActivity.java
@@ -62,8 +62,8 @@ public class BasicPlaybackListActivity extends Activity implements OnItemClickLi
       selectionMap.put("Widevine DASH Downloader", new PlayerSelectionOption("Q1cG85NTE6Df3A95XMMbKGsPg6yaEZGm", "BjcWYyOu1KK2DiKOkF41Z2k0X57l", apikey, secret, accountId,"http://ooyala.com", OfflineDownloadActivity.class));
       selectionMap.put("Widevine OOYALA Downloader", new PlayerSelectionOption("Q1cG85NTE6Df3A95XMMbKGsPg6yaEZGm", "BjcWYyOu1KK2DiKOkF41Z2k0X57l", apikey, secret, accountId,"http://ooyala.com", OoyalaOfflineDownloadActivity.class));
       selectionMap.put("Widevine Offline Stream Player", new PlayerSelectionOption("Q1cG85NTE6Df3A95XMMbKGsPg6yaEZGm", "BjcWYyOu1KK2DiKOkF41Z2k0X57l", apikey, secret, accountId,"http://ooyala.com", PlayerSelectionOption.OFFLINE_EMBED_CODE_PLAYBACK, OoyalaSkinOPTPlayerActivity.class));
-      selectionMap.put("Widevine OOYALA Downloader (URL)", new PlayerSelectionOption("dash_file", Stream.DELIVERY_TYPE_DASH, url, OoyalaOfflineDownloadActivity.class));
-      selectionMap.put("Widevine Offline Stream Player (URL)", new PlayerSelectionOption("dash_file", "http://ooyala.com", PlayerSelectionOption.OFFLINE_URL_PLAYBACK, OoyalaSkinOPTPlayerActivity.class));
+      selectionMap.put("OOYALA Downloader (URL)", new PlayerSelectionOption("dash_file", Stream.DELIVERY_TYPE_DASH, url, OoyalaOfflineDownloadActivity.class));
+      selectionMap.put("Offline Stream Player (URL)", new PlayerSelectionOption("dash_file", "http://ooyala.com", PlayerSelectionOption.OFFLINE_URL_PLAYBACK, OoyalaSkinOPTPlayerActivity.class));
     }
 
     setContentView(R.layout.list_activity_layout);

--- a/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/lists/BasicPlaybackListActivity.java
+++ b/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/lists/BasicPlaybackListActivity.java
@@ -12,6 +12,7 @@ import android.widget.AdapterView.OnItemClickListener;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
 
+import com.ooyala.android.item.Stream;
 import com.ooyala.sample.R;
 import com.ooyala.sample.players.OfflineDownloadActivity;
 import com.ooyala.sample.players.OoyalaOfflineDownloadActivity;
@@ -45,7 +46,7 @@ public class BasicPlaybackListActivity extends Activity implements OnItemClickLi
       selectionMap.put("Widevine Online Stream Player", new PlayerSelectionOption(getIntent().getStringExtra("embed_code"), getIntent().getStringExtra("pcode"), getIntent().getStringExtra("api_key"), getIntent().getStringExtra("secret_key"), getIntent().getStringExtra("account_id"), "http://ooyala.com", PlayerSelectionOption.ONLINE_PLAYBACK, OoyalaSkinOPTPlayerActivity.class));
       selectionMap.put("Widevine DASH Downloader", new PlayerSelectionOption(getIntent().getStringExtra("embed_code"), getIntent().getStringExtra("pcode"), getIntent().getStringExtra("api_key"), getIntent().getStringExtra("secret_key"), getIntent().getStringExtra("account_id"), "http://ooyala.com", OfflineDownloadActivity.class));
       selectionMap.put("Widevine OOYALA Downloader", new PlayerSelectionOption(getIntent().getStringExtra("embed_code"), getIntent().getStringExtra("pcode"), getIntent().getStringExtra("api_key"), getIntent().getStringExtra("secret_key"), getIntent().getStringExtra("account_id"), "http://ooyala.com", OoyalaOfflineDownloadActivity.class));
-      selectionMap.put("Widevine Offline Stream Player", new PlayerSelectionOption(getIntent().getStringExtra("embed_code"), getIntent().getStringExtra("pcode"), getIntent().getStringExtra("api_key"), getIntent().getStringExtra("secret_key"), getIntent().getStringExtra("account_id"), "http://ooyala.com", PlayerSelectionOption.OFFLINE_PLAYBACK, OoyalaSkinOPTPlayerActivity.class));
+      selectionMap.put("Widevine Offline Stream Player", new PlayerSelectionOption(getIntent().getStringExtra("embed_code"), getIntent().getStringExtra("pcode"), getIntent().getStringExtra("api_key"), getIntent().getStringExtra("secret_key"), getIntent().getStringExtra("account_id"), "http://ooyala.com", PlayerSelectionOption.OFFLINE_EMBED_CODE_PLAYBACK, OoyalaSkinOPTPlayerActivity.class));
 
     }
     else {
@@ -55,12 +56,14 @@ public class BasicPlaybackListActivity extends Activity implements OnItemClickLi
       String accountId = "";
       String apikey = "";
       String secret = "";
+      String url = "https://storage.googleapis.com/wvmedia/clear/h264/tears/tears.mpd";
 
       selectionMap.put("Widevine Online Stream Player", new PlayerSelectionOption("Q1cG85NTE6Df3A95XMMbKGsPg6yaEZGm", "BjcWYyOu1KK2DiKOkF41Z2k0X57l", apikey, secret, accountId,"http://ooyala.com", PlayerSelectionOption.ONLINE_PLAYBACK, OoyalaSkinOPTPlayerActivity.class));
       selectionMap.put("Widevine DASH Downloader", new PlayerSelectionOption("Q1cG85NTE6Df3A95XMMbKGsPg6yaEZGm", "BjcWYyOu1KK2DiKOkF41Z2k0X57l", apikey, secret, accountId,"http://ooyala.com", OfflineDownloadActivity.class));
       selectionMap.put("Widevine OOYALA Downloader", new PlayerSelectionOption("Q1cG85NTE6Df3A95XMMbKGsPg6yaEZGm", "BjcWYyOu1KK2DiKOkF41Z2k0X57l", apikey, secret, accountId,"http://ooyala.com", OoyalaOfflineDownloadActivity.class));
-      selectionMap.put("Widevine Offline Stream Player", new PlayerSelectionOption("Q1cG85NTE6Df3A95XMMbKGsPg6yaEZGm", "BjcWYyOu1KK2DiKOkF41Z2k0X57l", apikey, secret, accountId,"http://ooyala.com", PlayerSelectionOption.OFFLINE_PLAYBACK, OoyalaSkinOPTPlayerActivity.class));
-
+      selectionMap.put("Widevine Offline Stream Player", new PlayerSelectionOption("Q1cG85NTE6Df3A95XMMbKGsPg6yaEZGm", "BjcWYyOu1KK2DiKOkF41Z2k0X57l", apikey, secret, accountId,"http://ooyala.com", PlayerSelectionOption.OFFLINE_EMBED_CODE_PLAYBACK, OoyalaSkinOPTPlayerActivity.class));
+      selectionMap.put("Widevine OOYALA Downloader (URL)", new PlayerSelectionOption("dash_file", Stream.DELIVERY_TYPE_DASH, url, OoyalaOfflineDownloadActivity.class));
+      selectionMap.put("Widevine Offline Stream Player (URL)", new PlayerSelectionOption("dash_file", "http://ooyala.com", PlayerSelectionOption.OFFLINE_URL_PLAYBACK, OoyalaSkinOPTPlayerActivity.class));
     }
 
     setContentView(R.layout.list_activity_layout);
@@ -106,6 +109,8 @@ public class BasicPlaybackListActivity extends Activity implements OnItemClickLi
     intent.putExtra("domain", selection.getDomain());
     intent.putExtra("selection_name", selectionAdapter.getItem(pos));
     intent.putExtra("playback_type", selection.getPlaybackType());
+    intent.putExtra("delivery_type", selection.getDeliveryType());
+    intent.putExtra("url", selection.getUrl());
     startActivity(intent);
     return;
   }

--- a/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/players/OoyalaOfflineDownloadActivity.java
+++ b/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/players/OoyalaOfflineDownloadActivity.java
@@ -14,6 +14,7 @@ import android.widget.ListView;
 import android.widget.TextView;
 import android.widget.Toast;
 
+import com.google.android.exoplayer2.upstream.cache.Cache;
 import com.ooyala.android.EmbedTokenGenerator;
 import com.ooyala.android.EmbedTokenGeneratorCallback;
 import com.ooyala.android.EmbeddedSecureURLGenerator;
@@ -25,6 +26,7 @@ import com.ooyala.android.offline.options.OoyalaDownloadOptions;
 import com.ooyala.android.util.DebugMode;
 import com.ooyala.sample.DemoApplication;
 import com.ooyala.sample.R;
+import com.ooyala.sample.utils.PlayerSelectionOption;
 import com.ooyala.sample.utils.Utils;
 
 import java.io.File;
@@ -51,7 +53,7 @@ public class OoyalaOfflineDownloadActivity extends Activity implements DownloadL
 	private static final int MAX_RETRY_COUNT = 3;
 	private static final float MIN_PROGRESS = 0.f;
 	private static final float MAX_PROGRESS = 100.f;
-	private static TaskInfo TASK_INFO;
+
 
 	private String EMBED;
 	private String PCODE;
@@ -62,11 +64,15 @@ public class OoyalaOfflineDownloadActivity extends Activity implements DownloadL
 	private String APIKEY = "";
 	private String SECRET = "";
 
+	private String URL;
+	private String DELIVERY_TYPE;
+
 	private Downloader downloader;
 	private OoyalaDownloadOptions options;
 	private Collection<Integer> bitrateValues = new ArrayList<>();
 	private File folder;
 	private int retryCount;
+	private TaskInfo taskInfo;
 
 	private View dialogView;
 	private TextView progressView;
@@ -77,11 +83,12 @@ public class OoyalaOfflineDownloadActivity extends Activity implements DownloadL
 	private Handler handler;
 	private Runnable updateProgress = () -> {
 		handler.postDelayed(this.updateProgress, UPDATE_TIME);
-		if (TASK_INFO != null) {
-			float progress = Utils.clamp(downloader.getDownloadPercentage(TASK_INFO.taskId),
+		taskInfo = retrieveTaskInfo();
+		if (taskInfo != null) {
+			float progress = Utils.clamp(downloader.getDownloadPercentage(taskInfo.taskId),
 					MIN_PROGRESS, MAX_PROGRESS);
 			if (progress > MIN_PROGRESS && progress <= MAX_PROGRESS
-					&& TASK_INFO.state == TaskInfo.STATE_STARTED) {
+					&& taskInfo.state == TaskInfo.STATE_STARTED) {
 				String text = getString(R.string.progress_text, progress);
 				progressView.setText(text);
 			}
@@ -103,16 +110,19 @@ public class OoyalaOfflineDownloadActivity extends Activity implements DownloadL
 		APIKEY = getIntent().getExtras().getString("api_key");
 		SECRET = getIntent().getExtras().getString("secret_key");
 		ACCOUNT_ID = getIntent().getExtras().getString("account_id");
+		DELIVERY_TYPE = getIntent().getExtras().getString("delivery_type");
+		URL = getIntent().getExtras().getString("url");
 
 		progressView = findViewById(R.id.progress_text);
 		handler = new Handler(getMainLooper());
 
+		taskInfo = retrieveTaskInfo();
 		folder = Environment.getExternalStoragePublicDirectory(Environment.DIRECTORY_MOVIES);
-		options = new OoyalaDownloadOptions.Builder(PCODE, EMBED, DOMAIN, folder)
-				.setEmbedTokenGenerator(this)
-				.build();
+
+		initializeDownloadOptions();
 		DownloaderFactory factory = new DownloaderFactory();
-		downloader = factory.createOoyalaDownloader(this, ((DemoApplication) getApplication()).getDownloadCache(), options);
+		Cache cache = ((DemoApplication) getApplication()).getDownloadCache();
+		downloader = factory.createOoyalaDownloader(this, cache, options);
 
 		Button startButton = findViewById(R.id.start_button);
 		startButton.setOnClickListener(v -> {
@@ -130,8 +140,8 @@ public class OoyalaOfflineDownloadActivity extends Activity implements DownloadL
 		Button pauseButton = findViewById(R.id.pause_button);
 		pauseButton.setOnClickListener(v -> {
 			handler.removeCallbacks(updateProgress);
-			if (TASK_INFO != null) {
-				float progress = Utils.clamp(downloader.getDownloadPercentage(TASK_INFO.taskId),
+			if (taskInfo != null) {
+				float progress = Utils.clamp(downloader.getDownloadPercentage(taskInfo.taskId),
 						MIN_PROGRESS, MAX_PROGRESS);
 				String text = getString(R.string.paused_text, progress);
 				progressView.setText(text);
@@ -141,16 +151,32 @@ public class OoyalaOfflineDownloadActivity extends Activity implements DownloadL
 
 		Button deleteButton = findViewById(R.id.delete_button);
 		deleteButton.setOnClickListener(v -> {
-			if (TASK_INFO == null) {
+			if (taskInfo == null) {
 				progressView.setText(R.string.deletion_completed_text);
 				return;
 			}
 			downloader.cancel();
-			downloader.delete(TASK_INFO.taskId);
+			downloader.delete(taskInfo.taskId);
 		});
 
 		Button requestButton = findViewById(R.id.request_bitrate_and_start_button);
 		requestButton.setOnClickListener(v -> downloader.requestBitrates());
+	}
+
+	private void initializeDownloadOptions() {
+		if (URL.equals(PlayerSelectionOption.UNDEFINED_VALUE)) {
+			options = new OoyalaDownloadOptions.Builder(PCODE, EMBED, DOMAIN, folder)
+					.setEmbedTokenGenerator(this)
+					.build();
+		} else {
+			options = new OoyalaDownloadOptions.Builder(EMBED, DELIVERY_TYPE, URL)
+					.setBitrate(0)
+					.build();
+		}
+	}
+
+	private TaskInfo retrieveTaskInfo() {
+		return ((DemoApplication) getApplication()).retrieveCurrentTaskInfo(EMBED);
 	}
 
 	@Override
@@ -170,7 +196,7 @@ public class OoyalaOfflineDownloadActivity extends Activity implements DownloadL
 	@Override
 	public void onStarted(TaskInfo taskInfo) {
 		if (!taskInfo.isRemoveAction) {
-			OoyalaOfflineDownloadActivity.TASK_INFO = taskInfo;
+			((DemoApplication) getApplication()).addDownloadTask(EMBED, taskInfo);
 		}
 	}
 

--- a/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/utils/PlayerSelectionOption.java
+++ b/PlaybackLab/DownloadToOwnSampleApp/app/src/main/java/com/ooyala/sample/utils/PlayerSelectionOption.java
@@ -2,6 +2,12 @@ package com.ooyala.sample.utils;
 
 import android.app.Activity;
 
+import java.lang.annotation.Documented;
+import java.lang.annotation.Retention;
+import java.lang.annotation.RetentionPolicy;
+
+import androidx.annotation.IntDef;
+
 /**
  * This is used to store information of a sample activity for use in a Map or List
  *
@@ -9,8 +15,20 @@ import android.app.Activity;
 public class PlayerSelectionOption {
 
   public static final int ONLINE_PLAYBACK = 0;  // enforce online playback
-  public static final int OFFLINE_PLAYBACK = 1; // enforce offline playback
-  public static final int OFFLINE_ONLINE_PLAYBACK = 2; // will try offline playback if possible, else try online playback
+  public static final int OFFLINE_EMBED_CODE_PLAYBACK = 1; // enforce offline playback
+  public static final int OFFLINE_URL_PLAYBACK = 2; // enforce offline playback
+  public static final int OFFLINE_ONLINE_PLAYBACK = 3; // will try offline playback if possible, else try online playback
+  public static final String UNDEFINED_VALUE = "UNDEFINED_VALUE";
+
+  /**
+   * The type of the downloader that was used for downloading media files.
+   */
+  @Documented
+  @Retention(RetentionPolicy.SOURCE)
+  @IntDef({ONLINE_PLAYBACK, OFFLINE_EMBED_CODE_PLAYBACK, OFFLINE_URL_PLAYBACK, OFFLINE_ONLINE_PLAYBACK})
+  public @interface PlaybackType {
+  }
+
   private String embedCode;
   private Class <? extends Activity> activity;
   private String pcode;
@@ -18,21 +36,14 @@ public class PlayerSelectionOption {
   private String apiKey;
   private String secretKey;
   private String accountId;
-  private int playbackType = OFFLINE_ONLINE_PLAYBACK;
+  private String deliveryType = UNDEFINED_VALUE;
+  private String url = UNDEFINED_VALUE;
+  private @PlaybackType
+  int playbackType = OFFLINE_ONLINE_PLAYBACK;
 
-
-
-  public PlayerSelectionOption(String embedCode, String pcode, String apiKey, String secretKey,
-                               String accountId, String domain, int playbackType, Class<? extends Activity> activity) {
-    this.embedCode = embedCode;
-    this.activity = activity;
-    this.pcode = pcode;
-    this.domain = domain;
-    this.apiKey = apiKey;
-    this.secretKey = secretKey;
-    this.accountId = accountId;
-    this.playbackType = playbackType;
-  }
+  /**
+   * Create a {@link PlayerSelectionOption} to download a media file by embed code
+   */
   public PlayerSelectionOption(String embedCode, String pcode, String apiKey, String secretKey,
                                String accountId, String domain, Class<? extends Activity> activity) {
     this.embedCode = embedCode;
@@ -44,15 +55,47 @@ public class PlayerSelectionOption {
     this.accountId = accountId;
   }
 
-  public PlayerSelectionOption(String embedCode, String pcode, String domain, Class<? extends Activity> activity) {
-    this.embedCode = embedCode;
-    this.activity = activity;
-    this.pcode = pcode;
-    this.domain = domain;
+  /**
+   * Create a {@link PlayerSelectionOption} to download a media file by embed code
+   */
+  public PlayerSelectionOption(String embedCode, String pcode, String apiKey, String secretKey,
+                               String accountId, String domain, @PlaybackType int playbackType,
+                               Class<? extends Activity> activity) {
+    this(embedCode, pcode, apiKey, secretKey, accountId, domain, activity);
+    this.playbackType = playbackType;
+  }
+
+  /**
+   * Create a {@link PlayerSelectionOption} to download a media file by predefined URL
+   *
+   * @param embedCode    - the embed code. It is the unique identifier of the media file that
+   *                     will be used as a file name for downloading
+   * @param deliveryType - the delivery type. The following types have to be used
+   *                     {@link com.ooyala.android.item.Stream#DELIVERY_TYPE_DASH},
+   *                     {@link com.ooyala.android.item.Stream#DELIVERY_TYPE_HLS}.
+   * @param url          - the URL by which the file will be downloaded
+   * @param activity     - the {@link Activity}
+   */
+  public PlayerSelectionOption(String embedCode, String deliveryType, String url,
+                               Class<? extends Activity> activity) {
+    this(embedCode, UNDEFINED_VALUE, UNDEFINED_VALUE, UNDEFINED_VALUE, UNDEFINED_VALUE,
+        UNDEFINED_VALUE, activity);
+    this.deliveryType = deliveryType;
+    this.url = url;
+  }
+
+  /**
+   * Create a {@link PlayerSelectionOption} to playback a media file that was downloaded using URL
+   */
+  public PlayerSelectionOption(String embedCode, String domain, @PlaybackType int playbackType,
+                               Class<? extends Activity> activity) {
+    this(embedCode, UNDEFINED_VALUE, UNDEFINED_VALUE, UNDEFINED_VALUE, UNDEFINED_VALUE, domain, activity);
+    this.playbackType = playbackType;
   }
 
   /**
    * Get the pcode for this sample
+   *
    * @return the pcode
    */
   public String getPcode() {
@@ -61,6 +104,7 @@ public class PlayerSelectionOption {
 
   /**
    * Get the domain for this sample
+   *
    * @return the domain
    */
   public String getDomain() {
@@ -69,6 +113,7 @@ public class PlayerSelectionOption {
 
   /**
    * Get the embed code for this sample
+   *
    * @return the embed code
    */
   public String getEmbedCode() {
@@ -85,6 +130,7 @@ public class PlayerSelectionOption {
 
   /**
    * Get the secretkey for this sample
+   *
    * @return the secretKey
    */
   public String getSecretKey() {
@@ -93,6 +139,7 @@ public class PlayerSelectionOption {
 
   /**
    * Get the accountid for this sample
+   *
    * @return the accountId
    */
   public String getAccountId() {
@@ -102,17 +149,39 @@ public class PlayerSelectionOption {
 
   /**
    * Get the playbackType for this sample
+   *
    * @return the playbackType
    */
-  public int getPlaybackType() {
+  public @PlaybackType
+  int getPlaybackType() {
     return playbackType;
   }
 
   /**
    * Get the activity to use for this sample
+   *
    * @return the activity to launch
    */
   public Class <? extends Activity> getActivity() {
     return this.activity;
+  }
+
+  /**
+   * Get the delivery type of the media asset that will be downloaded using a predefined URL
+   *
+   * @return one of the following delivery types {@link com.ooyala.android.item.Stream#DELIVERY_TYPE_DASH},
+   * {@link com.ooyala.android.item.Stream#DELIVERY_TYPE_HLS}
+   */
+  public String getDeliveryType() {
+    return deliveryType;
+  }
+
+  /**
+   * Get the predefined URL
+   *
+   * @return the URL by which the file will be downloaded
+   */
+  public String getUrl() {
+    return url;
   }
 }


### PR DESCRIPTION
Added opportunity to download a media file by URL and delivery type.
Basic Playback screen was extended by
- `OOYALA Downloader (URL)` the screen is created to demonstrate the downloading process using URL
- `Offline Stream Player (URL)` the screen is created to demonstrate the downloaded by URL asset playback