### PR TITLE
[PLAYER-5460] Fixed react native dependencies for chromecast sample app

### DIFF
--- a/ChromecastSampleApp/app/build.gradle
+++ b/ChromecastSampleApp/app/build.gradle
@@ -118,6 +118,7 @@ dependencies {
     implementation "com.google.android.gms:play-services-cast-framework:$rootProject.gmsCastVersion"
 
     //react-native dependencies
+    implementation "com.facebook.infer.annotation:infer-annotation:$rootProject.inferAnnotationVersion"
     implementation "com.facebook.fresco:fresco:$rootProject.frescoVersion"
     implementation "com.facebook.fresco:imagepipeline-okhttp3:$rootProject.frescoVersion"
     implementation "com.facebook.soloader:soloader:$rootProject.soloaderVersion"

--- a/ChromecastSampleApp/build.gradle
+++ b/ChromecastSampleApp/build.gradle
@@ -27,6 +27,15 @@ buildscript {
         bintrayVersion = '0.8.1'
         gradleVersion = '3.2.1'
         mavenGradleVersion = '1.5'
+
+        // react-native dependencies
+        inferAnnotationVersion = '0.11.2'
+        frescoVersion = '1.10.0'
+        soloaderVersion = '0.5.1'
+        findbugsVersion = '3.0.2'
+        okhttpVersion = '3.12.1'
+        okioVersion = '1.15.0'
+        androidJscVersion = 'r174650'
     }
 
 


### PR DESCRIPTION
That changes fixing  two issues:
PLAYER-5461    [Android] [ChromecastSampleApp] [Skin] App crashes when clicked on “Use Skin” and play any asset.  
PLAYER-5460    [Android] [ChromecastSampleApp] Unable to build the app when launched independently from android studio and getting ‘frescoVersion’ error.