### PR TITLE
[PLAYER-5330] Add sample how to listen changing ui visibility

### DIFF
--- a/OoyalaSkinSampleApp/app/src/main/java/com/ooyala/sample/players/OoyalaSkinPlayerActivity.java
+++ b/OoyalaSkinSampleApp/app/src/main/java/com/ooyala/sample/players/OoyalaSkinPlayerActivity.java
@@ -7,6 +7,7 @@ import com.ooyala.android.Environment;
 import com.ooyala.android.OoyalaPlayer;
 import com.ooyala.android.PlayerDomain;
 import com.ooyala.android.configuration.Options;
+import com.ooyala.android.util.DebugMode;
 import com.ooyala.sample.R;
 import com.ooyala.android.skin.OoyalaSkinLayout;
 import com.ooyala.android.skin.OoyalaSkinLayoutController;
@@ -50,6 +51,7 @@ public class OoyalaSkinPlayerActivity extends AbstractHookActivity {
 			playerLayoutController = new OoyalaSkinLayoutController(getApplication(), skinLayout, player, skinOptions);
 			//Add observer to listen to fullscreen open and close events
 			playerLayoutController.addObserver(this);
+      playerLayoutController.addOnVisibilityControlsChangeListener(isVisible -> DebugMode.logV(TAG, "Ui is visible: " + isVisible));
 			player.addObserver(this);
 
 			if (player.setEmbedCode(embedCode)) {


### PR DESCRIPTION
**Task:** It was neccessary to add callback in Android SDK when scrubber bar visibility is changed 
**Actions:** I add passing this event from skin to OoyalaSkinLayoutController via bridge. And write sample how to use it OoyalaSkinPlayerActivity
**Result** We can listen this event via instance of OoyalaSkinLayoutController and method addOnVisibilityControlsChangeListener. In console we see: 
 Ui is visible: true
 Ui is visible: false
