### PR TITLE
[PLAYER-5508] Change behavior of minicontroller

### DIFF
--- a/ChromecastSampleApp/app/src/main/java/com/ooyala/sample/common/CastActivity.java
+++ b/ChromecastSampleApp/app/src/main/java/com/ooyala/sample/common/CastActivity.java
@@ -57,7 +57,7 @@ public abstract class CastActivity extends PlayerActivity {
 
   @Nullable
   @Override
-  protected String getCurrentEmbedCode() {
+  protected String getCurrentRemoteEmbedCode() {
     String currentEmbedCode = null;
     CastManager castManager = CastManager.getCastManager();
     if (castManager != null && castManager.getCastPlayer() != null) {

--- a/ChromecastSampleApp/app/src/main/java/com/ooyala/sample/common/CastActivity.java
+++ b/ChromecastSampleApp/app/src/main/java/com/ooyala/sample/common/CastActivity.java
@@ -3,6 +3,7 @@ package com.ooyala.sample.common;
 import android.os.Bundle;
 
 import com.ooyala.cast.CastManager;
+import com.ooyala.cast.CastPlayer;
 import com.ooyala.cast.RemoteDeviceConnector;
 
 import androidx.annotation.Nullable;
@@ -52,6 +53,17 @@ public abstract class CastActivity extends PlayerActivity {
       remoteDeviceConnector.registerToOoyalaPlayer(player);
       remoteDeviceConnector.sendAvailableCastDevicesToPlayer();
     }
+  }
+
+  @Nullable
+  @Override
+  protected String getCurrentEmbedCode() {
+    String currentEmbedCode = null;
+    CastManager castManager = CastManager.getCastManager();
+    if (castManager != null && castManager.getCastPlayer() != null) {
+      currentEmbedCode = castManager.getCastPlayer().getEmbedCode();
+    }
+    return currentEmbedCode;
   }
 
   @Override

--- a/ChromecastSampleApp/app/src/main/java/com/ooyala/sample/common/PlayerActivity.java
+++ b/ChromecastSampleApp/app/src/main/java/com/ooyala/sample/common/PlayerActivity.java
@@ -2,6 +2,7 @@ package com.ooyala.sample.common;
 
 import android.content.SharedPreferences;
 import android.os.Bundle;
+import android.text.TextUtils;
 import android.util.Log;
 
 import com.ooyala.android.EmbedTokenGenerator;
@@ -74,9 +75,23 @@ public abstract class PlayerActivity extends AppCompatActivity implements EmbedT
       player = new OoyalaPlayer(pcode, playerDomain, this, getOptions());
       initAndBindController();
       player.addObserver(this);
-      play(embedCode);
+
+      String currentEmbedCode = getCurrentEmbedCode();
+      if (TextUtils.isEmpty(currentEmbedCode)) {
+        play(embedCode);
+      } else {
+        play(currentEmbedCode);
+      }
     }
   }
+
+  /**
+   * Gets embed code that plays on remote device.
+   *
+   * @return current embed code that plays on remote device or null
+   */
+  @Nullable
+  abstract protected String getCurrentEmbedCode();
 
   protected abstract Options getOptions();
 

--- a/ChromecastSampleApp/app/src/main/java/com/ooyala/sample/common/PlayerActivity.java
+++ b/ChromecastSampleApp/app/src/main/java/com/ooyala/sample/common/PlayerActivity.java
@@ -76,11 +76,13 @@ public abstract class PlayerActivity extends AppCompatActivity implements EmbedT
       initAndBindController();
       player.addObserver(this);
 
-      String currentEmbedCode = getCurrentEmbedCode();
-      if (TextUtils.isEmpty(currentEmbedCode)) {
+      if (!TextUtils.isEmpty(embedCode)) {
         play(embedCode);
       } else {
-        play(currentEmbedCode);
+        String currentEmbedCode = getCurrentRemoteEmbedCode();
+        if (!TextUtils.isEmpty(currentEmbedCode)) {
+          play(currentEmbedCode);
+        }
       }
     }
   }
@@ -91,7 +93,7 @@ public abstract class PlayerActivity extends AppCompatActivity implements EmbedT
    * @return current embed code that plays on remote device or null
    */
   @Nullable
-  abstract protected String getCurrentEmbedCode();
+  abstract protected String getCurrentRemoteEmbedCode();
 
   protected abstract Options getOptions();
 
@@ -104,7 +106,17 @@ public abstract class PlayerActivity extends AppCompatActivity implements EmbedT
       secondEmbedCode = lastChosenParams.getString("secondEmbedCode", null);
       pcode = lastChosenParams.getString("pcode", "");
       domain = lastChosenParams.getString("domain", "");
+
+      removeUsedEmbedCodes(lastChosenParams);
     }
+  }
+
+  private void removeUsedEmbedCodes(SharedPreferences lastChosenParams) {
+    lastChosenParams
+        .edit()
+        .putString("embedcode", null)
+        .putString("secondEmbedCode", null)
+        .apply();
   }
 
   @Override


### PR DESCRIPTION
**Task** There is an issue related to incorrect behavior when user taps on minicontroller button: It leads to open previous embedcode instead of embed code of remote device. 
**Actions** I added several methods to get current embed code of cast player (contains embed code of remote device) into player activity. And add removing information about used embed code from sharedpreferences to avoid situation when we open the same embed code twice. 
**Result** When user taps on minicontroller - opens video that plays on remote device. 
When user taps on line from list of videos - opens chosen video. 