### PR TITLE
[PLAYER-5513][RecyclerView] Unexpected  pause after scrolling

### DIFF
--- a/PlaybackLab/FullscreenSampleApp/app/src/main/java/com/ooyala/sample/Constants.java
+++ b/PlaybackLab/FullscreenSampleApp/app/src/main/java/com/ooyala/sample/Constants.java
@@ -16,7 +16,6 @@ final class Constants {
 
         List<Data> dataList = new ArrayList<>();
         dataList.add(new Data("01YXgwYTrOLeUiHStOloFvUMIND47Bd4", pCode, domain));
-        dataList.add(new Data("twcTUwYTp48GRxWvJox06g_tFsOlXLQ0", pCode, domain));
         dataList.add(new Data("MwdHY0YTpNpYivE5SLxLc-wDBZUZCkqH", pCode, domain));
         dataList.add(new Data("5mZGtkYjqqz66Pl_mh3oZ8-PbNLKp1G7", pCode, domain));
         dataList.add(new Data("N3cGp0ZDrML1PxJUsRq2w2kMD777AwVF", pCode, domain));
@@ -24,7 +23,6 @@ final class Constants {
         dataList.add(new Data("N3cGp0ZDrML1PxJUsRq2w2kMD777AwVF", pCode, domain));
         dataList.add(new Data("5mZGtkYjqqz66Pl_mh3oZ8-PbNLKp1G7", pCode, domain));
         dataList.add(new Data("MwdHY0YTpNpYivE5SLxLc-wDBZUZCkqH", pCode, domain));
-        dataList.add(new Data("twcTUwYTp48GRxWvJox06g_tFsOlXLQ0", pCode, domain));
         dataList.add(new Data("01YXgwYTrOLeUiHStOloFvUMIND47Bd4", pCode, domain));
         return dataList;
     }

--- a/PlaybackLab/FullscreenSampleApp/app/src/main/java/com/ooyala/sample/PlayerAdapter.java
+++ b/PlaybackLab/FullscreenSampleApp/app/src/main/java/com/ooyala/sample/PlayerAdapter.java
@@ -26,8 +26,11 @@ public class PlayerAdapter extends RecyclerView.Adapter<PlayerHolder> {
     public void onBindViewHolder(@NonNull PlayerHolder holder, int position) {
         Data data = dataList.get(position);
         holder.setData(data);
+        holder.setIsRecyclable(false);
 
+        // PlayerHolder is initialized only once on start
         if (position == autoPlayIndex) {
+            autoPlayIndex = RecyclerView.NO_POSITION;
             // Play the media on start
             holder.init();
             holder.play();


### PR DESCRIPTION
**Issue:** 
While "playing" on swiping between the assets quickly, the playback pauses sometimes randomly for an asset.

**What have done**
- Initialize PlayerHolder from adapter only once in onBindViewHolder callback. Major work that related to playback, pausing and player initialization is handled via scrollListener callbacks.
- Remove assets with Ads.
