### PR TITLE
[PLAYER-5513] MultiplePlayerActivity: manage pause and playback media files carefully

### DIFF
--- a/PlaybackLab/FullscreenSampleApp/app/src/main/java/com/ooyala/sample/MediaPlayer.java
+++ b/PlaybackLab/FullscreenSampleApp/app/src/main/java/com/ooyala/sample/MediaPlayer.java
@@ -3,7 +3,7 @@ package com.ooyala.sample;
 import android.app.Activity;
 import android.view.LayoutInflater;
 import android.view.ViewGroup;
-
+import androidx.recyclerview.widget.RecyclerView;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
 import com.ooyala.android.OoyalaPlayer;
 import com.ooyala.android.PlayerDomain;
@@ -13,8 +13,6 @@ import com.ooyala.android.skin.OoyalaSkinLayoutController;
 import com.ooyala.android.util.DebugMode;
 import com.ooyala.sample.interfaces.LifeCycle;
 import com.ooyala.sample.interfaces.Player;
-
-import androidx.recyclerview.widget.RecyclerView;
 
 public class MediaPlayer implements Player, LifeCycle, DefaultHardwareBackBtnHandler {
 	private static final String TAG = MediaPlayer.class.getSimpleName();
@@ -109,6 +107,11 @@ public class MediaPlayer implements Player, LifeCycle, DefaultHardwareBackBtnHan
 	public boolean isPlaying() {
 		return player != null && player.isPlaying();
 	}
+
+    @Override
+    public boolean isPauseNeeded() {
+        return player != null && player.getDesiredState() != OoyalaPlayer.DesiredState.DESIRED_PAUSE;
+    }
 
 	@Override
 	public int getPlayheadTime() {

--- a/PlaybackLab/FullscreenSampleApp/app/src/main/java/com/ooyala/sample/MultiplePlayerAdapter.java
+++ b/PlaybackLab/FullscreenSampleApp/app/src/main/java/com/ooyala/sample/MultiplePlayerAdapter.java
@@ -2,14 +2,12 @@ package com.ooyala.sample;
 
 import android.app.Activity;
 import android.view.ViewGroup;
-
+import androidx.annotation.NonNull;
+import androidx.recyclerview.widget.RecyclerView;
 import com.ooyala.android.util.DebugMode;
 
 import java.util.ArrayList;
 import java.util.List;
-
-import androidx.annotation.NonNull;
-import androidx.recyclerview.widget.RecyclerView;
 
 public class MultiplePlayerAdapter extends RecyclerView.Adapter<MultiplePlayerHolder> {
 	private static final String TAG = MultiplePlayerAdapter.class.getSimpleName();
@@ -54,6 +52,7 @@ public class MultiplePlayerAdapter extends RecyclerView.Adapter<MultiplePlayerHo
 
 		if (position == autoPlayIndex) {
 			// Play the media on start
+            autoPlayIndex = RecyclerView.NO_POSITION;
 			holder.play();
 		}
 	}

--- a/PlaybackLab/FullscreenSampleApp/app/src/main/java/com/ooyala/sample/SinglePlayerActivity.java
+++ b/PlaybackLab/FullscreenSampleApp/app/src/main/java/com/ooyala/sample/SinglePlayerActivity.java
@@ -35,7 +35,6 @@ public class SinglePlayerActivity extends AppCompatActivity {
     private PlayerAdapter playerAdapter;
     private PagerSnapHelper snapHelper;
     private ScrollListener scrollListener;
-    private List<Data> dataList;
 
     private class ScrollListener extends RecyclerView.OnScrollListener {
         private int snapPosition = RecyclerView.NO_POSITION;
@@ -76,7 +75,7 @@ public class SinglePlayerActivity extends AppCompatActivity {
             updateCurrentDataPlayheadTime(snapPosition);
 
             MediaPlayer player = MediaPlayer.getInstance();
-            if (player.isPlaying()) {
+            if (player.isPauseNeeded()) {
                 pause(snapPosition);
             }
         }
@@ -102,7 +101,7 @@ public class SinglePlayerActivity extends AppCompatActivity {
         setContentView(R.layout.activity_players);
         ButterKnife.bind(this);
 
-        dataList = Constants.populateData();
+        List<Data> dataList = Constants.populateData();
 
         scrollListener = new ScrollListener();
         scrollListener.setSnapPosition(0);

--- a/PlaybackLab/FullscreenSampleApp/app/src/main/java/com/ooyala/sample/interfaces/Player.java
+++ b/PlaybackLab/FullscreenSampleApp/app/src/main/java/com/ooyala/sample/interfaces/Player.java
@@ -11,5 +11,7 @@ public interface Player {
 
 	boolean isPlaying();
 
+	boolean isPauseNeeded();
+
 	int getPlayheadTime();
 }


### PR DESCRIPTION
On RecyclerView.OnScrollListener  the property SCROLL_STATE_IDLE takes time to get called at the end of the item size and when scrolled up to the top of the RecyclerView. For the top item occasionally SCROLL_STATE_IDLE is not getting triggered at all.
However, it works fine in the middle of the scrolling.
I changed the logic of obtaining the snap position of the element located in the view and so changed the pause/play managing.