### PR TITLE
[PLAYER-5551] Get rid of android-jsc lib. Upgrade soloader ver to 0.6.0

### DIFF
--- a/AdvancedPlaybackSampleApp/app/build.gradle
+++ b/AdvancedPlaybackSampleApp/app/build.gradle
@@ -97,6 +97,5 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:$rootProject.okhttpVersion"
     implementation "com.squareup.okhttp3:okhttp-urlconnection:$rootProject.okhttpVersion"
     implementation "com.squareup.okio:okio:$rootProject.okioVersion"
-    implementation "org.webkit:android-jsc:$rootProject.androidJscVersion"
     implementation(group:'com.facebook', name:'react-native', version: rootProject.reactNativeVersion, ext:'aar')
 }

--- a/AdvancedPlaybackSampleApp/build.gradle
+++ b/AdvancedPlaybackSampleApp/build.gradle
@@ -37,7 +37,6 @@ buildscript {
         findbugsVersion = '3.0.2'
         okhttpVersion = '3.12.1'
         okioVersion = '1.15.0'
-        androidJscVersion = 'r174650'
     }
 
     repositories {

--- a/ChromecastSampleApp/app/build.gradle
+++ b/ChromecastSampleApp/app/build.gradle
@@ -118,7 +118,6 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:$rootProject.okhttpVersion"
     implementation "com.squareup.okhttp3:okhttp-urlconnection:$rootProject.okhttpVersion"
     implementation "com.squareup.okio:okio:$rootProject.okioVersion"
-    implementation "org.webkit:android-jsc:$rootProject.androidJscVersion"
     implementation(group:'com.facebook', name:'react-native', version: rootProject.reactNativeVersion, ext:'aar')
     implementation 'androidx.constraintlayout:constraintlayout:1.1.3'
     implementation 'androidx.recyclerview:recyclerview:1.0.0'

--- a/ChromecastSampleApp/build.gradle
+++ b/ChromecastSampleApp/build.gradle
@@ -36,7 +36,6 @@ buildscript {
         findbugsVersion = '3.0.2'
         okhttpVersion = '3.12.1'
         okioVersion = '1.15.0'
-        androidJscVersion = 'r174650'
     }
 
 

--- a/CompleteSampleApp/build.gradle
+++ b/CompleteSampleApp/build.gradle
@@ -25,7 +25,6 @@ buildscript {
 
         // react-native dependencies
         reactNativeVersion = '0.59.4'
-        androidJscVersion = 'r174650'
         findbugsVersion = '3.0.0'
         frescoVersion = '1.3.0'
         imagePipelineVersion = '1.3.0'

--- a/ExoPlayerSampleApp/app/build.gradle
+++ b/ExoPlayerSampleApp/app/build.gradle
@@ -114,6 +114,5 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:$rootProject.okhttpVersion"
     implementation "com.squareup.okhttp3:okhttp-urlconnection:$rootProject.okhttpVersion"
     implementation "com.squareup.okio:okio:$rootProject.okioVersion"
-    implementation "org.webkit:android-jsc:$rootProject.androidJscVersion"
     implementation(group:'com.facebook', name:'react-native', version: rootProject.reactNativeVersion, ext:'aar')
 }

--- a/ExoPlayerSampleApp/build.gradle
+++ b/ExoPlayerSampleApp/build.gradle
@@ -33,7 +33,6 @@ buildscript {
         findbugsVersion = '3.0.2'
         okhttpVersion = '3.12.1'
         okioVersion = '1.15.0'
-        androidJscVersion = 'r174650'
     }
 
     repositories {

--- a/OoyalaSkinSampleApp/app/build.gradle
+++ b/OoyalaSkinSampleApp/app/build.gradle
@@ -20,10 +20,6 @@ android {
         jumboMode true
     }
 
-    packagingOptions {
-        pickFirst '**/libjsc.so'
-    }
-
     buildTypes {
         release {
             minifyEnabled false
@@ -122,6 +118,5 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:$rootProject.okhttpVersion"
     implementation "com.squareup.okhttp3:okhttp-urlconnection:$rootProject.okhttpVersion"
     implementation "com.squareup.okio:okio:$rootProject.okioVersion"
-    implementation "org.webkit:android-jsc:$rootProject.androidJscVersion"
     implementation(group:'com.facebook', name:'react-native', version: rootProject.reactNativeVersion, ext:'aar')
 }

--- a/OoyalaSkinSampleApp/build.gradle
+++ b/OoyalaSkinSampleApp/build.gradle
@@ -37,11 +37,10 @@ buildscript {
         reactNativeVersion = '0.59.4'
         inferAnnotationVersion = '0.11.2'
         frescoVersion = '1.10.0'
-        soloaderVersion = '0.5.1'
+        soloaderVersion = '0.6.0'
         findbugsVersion = '3.0.2'
         okhttpVersion = '3.12.1'
         okioVersion = '1.15.0'
-        androidJscVersion = 'r174650'
     }
 
     repositories {

--- a/PlaybackLab/DownloadToOwnSampleApp/app/build.gradle
+++ b/PlaybackLab/DownloadToOwnSampleApp/app/build.gradle
@@ -111,6 +111,5 @@ dependencies {
   implementation "com.squareup.okhttp3:okhttp:$rootProject.okhttpVersion"
   implementation "com.squareup.okhttp3:okhttp-urlconnection:$rootProject.okhttpVersion"
   implementation "com.squareup.okio:okio:$rootProject.okioVersion"
-  implementation "org.webkit:android-jsc:$rootProject.androidJscVersion"
   implementation(group:'com.facebook', name:'react-native', version: rootProject.reactNativeVersion, ext:'aar')
 }

--- a/PlaybackLab/DownloadToOwnSampleApp/build.gradle
+++ b/PlaybackLab/DownloadToOwnSampleApp/build.gradle
@@ -36,7 +36,6 @@ buildscript {
         findbugsVersion = '3.0.2'
         okhttpVersion = '3.12.1'
         okioVersion = '1.15.0'
-        androidJscVersion = 'r174650'
     }
 
     repositories {

--- a/PlaybackLab/FullscreenSampleApp/app/build.gradle
+++ b/PlaybackLab/FullscreenSampleApp/app/build.gradle
@@ -92,7 +92,6 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:$rootProject.okhttpVersion"
     implementation "com.squareup.okhttp3:okhttp-urlconnection:$rootProject.okhttpVersion"
     implementation "com.squareup.okio:okio:$rootProject.okioVersion"
-    implementation "org.webkit:android-jsc:$rootProject.androidJscVersion"
     implementation(group:'com.facebook', name:'react-native', version: rootProject.reactNativeVersion, ext:'aar')
 }
 

--- a/PlaybackLab/FullscreenSampleApp/build.gradle
+++ b/PlaybackLab/FullscreenSampleApp/build.gradle
@@ -38,7 +38,6 @@ buildscript {
         findbugsVersion = '3.0.2'
         okhttpVersion = '3.12.1'
         okioVersion = '1.15.0'
-        androidJscVersion = 'r174650'
     }
 
     repositories {

--- a/PulseSampleApp/app/build.gradle
+++ b/PulseSampleApp/app/build.gradle
@@ -118,6 +118,5 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:$rootProject.okhttpVersion"
     implementation "com.squareup.okhttp3:okhttp-urlconnection:$rootProject.okhttpVersion"
     implementation "com.squareup.okio:okio:$rootProject.okioVersion"
-    implementation "org.webkit:android-jsc:$rootProject.androidJscVersion"
     implementation(group:'com.facebook', name:'react-native', version: rootProject.reactNativeVersion, ext:'aar')
 }

--- a/PulseSampleApp/build.gradle
+++ b/PulseSampleApp/build.gradle
@@ -38,7 +38,6 @@ buildscript {
         findbugsVersion = '3.0.2'
         okhttpVersion = '3.12.1'
         okioVersion = '1.15.0'
-        androidJscVersion = 'r174650'
     }
 
     repositories {

--- a/VRSampleApp/app/build.gradle
+++ b/VRSampleApp/app/build.gradle
@@ -107,7 +107,6 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:$rootProject.okhttpVersion"
     implementation "com.squareup.okhttp3:okhttp-urlconnection:$rootProject.okhttpVersion"
     implementation "com.squareup.okio:okio:$rootProject.okioVersion"
-    implementation "org.webkit:android-jsc:$rootProject.androidJscVersion"
     implementation(group:'com.facebook', name:'react-native', version: rootProject.reactNativeVersion, ext:'aar')
 
     // VR

--- a/VRSampleApp/build.gradle
+++ b/VRSampleApp/build.gradle
@@ -38,7 +38,6 @@ buildscript {
         findbugsVersion = '3.0.2'
         okhttpVersion = '3.12.1'
         okioVersion = '1.15.0'
-        androidJscVersion = 'r174650'
 
         //VR
         vrAudioVersion = '1.80.0'

--- a/VRSampleAppKotlin/app/build.gradle
+++ b/VRSampleAppKotlin/app/build.gradle
@@ -111,7 +111,6 @@ dependencies {
     implementation "com.squareup.okhttp3:okhttp:$rootProject.okhttpVersion"
     implementation "com.squareup.okhttp3:okhttp-urlconnection:$rootProject.okhttpVersion"
     implementation "com.squareup.okio:okio:$rootProject.okioVersion"
-    implementation "org.webkit:android-jsc:$rootProject.androidJscVersion"
     implementation(group:'com.facebook', name:'react-native', version: rootProject.reactNativeVersion, ext:'aar')
 
     // VR

--- a/VRSampleAppKotlin/build.gradle
+++ b/VRSampleAppKotlin/build.gradle
@@ -37,7 +37,6 @@ buildscript {
         findbugsVersion = '3.0.2'
         okhttpVersion = '3.12.1'
         okioVersion = '1.15.0'
-        androidJscVersion = 'r174650'
 
         //VR
         vrAudioVersion = '1.80.0'

--- a/build.gradle
+++ b/build.gradle
@@ -44,11 +44,10 @@ buildscript {
         reactNativeVersion = '0.59.4'
         inferAnnotationVersion = '0.11.2'
         frescoVersion = '1.10.0'
-        soloaderVersion = '0.5.1'
+        soloaderVersion = '0.6.0'
         findbugsVersion = '3.0.2'
         okhttpVersion = '3.12.1'
         okioVersion = '1.15.0'
-        androidJscVersion = 'r174650'
 
 
         // VR


### PR DESCRIPTION
Basically, facebook ReactNative lib contains the other version of android-jsc lib that was referenced to another dependent library version **libc++_shared.so.** 
The old version of android-jsc [lib](https://github.com/facebook/android-jsc)  has the following dependency: **libgnustl_shared.so**
