### PR TITLE
[PLYER-5524] Let the user choose between Skin and the regular UI options and apply the options to ChromeCast MiniControllerFragment

### DIFF
--- a/ChromecastSampleApp/app/src/main/AndroidManifest.xml
+++ b/ChromecastSampleApp/app/src/main/AndroidManifest.xml
@@ -17,23 +17,27 @@
         android:theme="@style/Theme.CastVideosTheme"
         android:name=".SampleApplication"
         android:usesCleartextTraffic="true">
+
         <activity android:name=".ChromecastListActivity">
             <intent-filter>
                 <action android:name="android.intent.action.MAIN" />
                 <category android:name="android.intent.category.LAUNCHER" />
             </intent-filter>
         </activity>
+
         <activity
             android:name=".simple.SimpleCastPlayerActivity"
             android:configChanges="keyboardHidden|orientation|screenSize"
             android:label="@string/app_name"
             android:launchMode="singleTop"
             android:textColor="#ffffff" />
-        <activity
-            android:name=".skin.SkinCastPlayerActivity"
-            android:configChanges="keyboardHidden|orientation|screenSize" />
-        <activity android:name=".custom.CustomUiPlayerActivity" />
 
+        <activity android:name=".skin.SkinCastPlayerActivity"
+                  android:configChanges="keyboardHidden|orientation|screenSize"/>
+
+        <activity android:name=".common.ExpandedControllerActivity"
+                  android:noHistory="true"
+                  android:configChanges="keyboardHidden|orientation|screenSize"/>
         <meta-data
             android:name="com.google.android.gms.cast.framework.OPTIONS_PROVIDER_CLASS_NAME"
             android:value="com.ooyala.sample.CastOptionsProvider" />

--- a/ChromecastSampleApp/app/src/main/java/com/ooyala/sample/CastOptionsProvider.java
+++ b/ChromecastSampleApp/app/src/main/java/com/ooyala/sample/CastOptionsProvider.java
@@ -8,6 +8,7 @@ import com.google.android.gms.cast.framework.OptionsProvider;
 import com.google.android.gms.cast.framework.SessionProvider;
 import com.google.android.gms.cast.framework.media.CastMediaOptions;
 import com.google.android.gms.cast.framework.media.NotificationOptions;
+import com.ooyala.sample.common.ExpandedControllerActivity;
 import com.ooyala.sample.simple.SimpleCastPlayerActivity;
 
 import java.util.List;
@@ -22,16 +23,17 @@ public class CastOptionsProvider implements OptionsProvider {
   public CastOptions getCastOptions(Context context) {
     NotificationOptions notificationOptions = new NotificationOptions.Builder()
         //Set here the activity that contain player.
-        //For this sample there are 3 activity that can play video:
+        //For this sample there are 2 activities that can play video:
         //SimpleCastPlayerActivity, SkinCastPlayerActivity
-        //We set as example SimpleCastPlayerActivity
+        //ExpandedControllerActivity starts SimpleCastPlayerActivity or SkinCastPlayerActivity depending on
+        // the chosen skin options
         .setTargetActivityClassName(SimpleCastPlayerActivity.class.getName())
         .setPlayDrawableResId(R.drawable.ic_media_play_light)
         .setPauseDrawableResId(R.drawable.ic_media_pause_light)
         .build();
     CastMediaOptions mediaOptions = new CastMediaOptions.Builder()
         .setNotificationOptions(notificationOptions)
-        .setExpandedControllerActivityClassName(SimpleCastPlayerActivity.class.getName())
+        .setExpandedControllerActivityClassName(ExpandedControllerActivity.class.getName())
         .build();
 
     return new CastOptions.Builder()

--- a/ChromecastSampleApp/app/src/main/java/com/ooyala/sample/ChromecastListActivity.java
+++ b/ChromecastSampleApp/app/src/main/java/com/ooyala/sample/ChromecastListActivity.java
@@ -10,14 +10,12 @@ import android.widget.AdapterView;
 import android.widget.ArrayAdapter;
 import android.widget.ListView;
 import android.widget.RadioGroup;
-
+import androidx.appcompat.app.AppCompatActivity;
+import androidx.appcompat.widget.Toolbar;
 import com.google.android.gms.cast.framework.CastButtonFactory;
 import com.google.android.gms.cast.framework.media.widget.MiniControllerFragment;
 import com.ooyala.sample.simple.SimpleCastPlayerActivity;
 import com.ooyala.sample.skin.SkinCastPlayerActivity;
-
-import androidx.appcompat.app.AppCompatActivity;
-import androidx.appcompat.widget.Toolbar;
 
 public class ChromecastListActivity extends AppCompatActivity implements AdapterView.OnItemClickListener {
   private static final String TAG = "ChromecastListActivity";
@@ -30,6 +28,8 @@ public class ChromecastListActivity extends AppCompatActivity implements Adapter
     super.onCreate(savedInstanceState);
     setContentView(R.layout.start_view);
     setupActionBar();
+    setupSkinChooser();
+
     videoList = getVideoList();
 
     MiniControllerFragment miniControllerFragment = (MiniControllerFragment) getSupportFragmentManager().findFragmentById(R.id.cast_mini_controller);
@@ -47,20 +47,7 @@ public class ChromecastListActivity extends AppCompatActivity implements Adapter
 
   @Override
   public void onItemClick(AdapterView<?> parent, View view, int position, long id) {
-    final Intent intent;
-    RadioGroup skinChooser = findViewById(R.id.player_type_chooser);
-    int radioButtonID = skinChooser.getCheckedRadioButtonId();
-    switch (radioButtonID) {
-      case R.id.radioButtonSkin:
-        intent = new Intent(this, SkinCastPlayerActivity.class);
-        break;
-      case R.id.radioButtonSimple:
-        intent = new Intent(this, SimpleCastPlayerActivity.class);
-        break;
-      default:
-        intent = new Intent(this, SimpleCastPlayerActivity.class);
-    }
-
+    final Intent intent = new Intent(this, ((SampleApplication) getApplication()).getExpandedControllerActivity());
     SharedPreferences lastChosenParams = getSharedPreferences("LastChosenParams", MODE_PRIVATE);
     lastChosenParams
         .edit()
@@ -84,6 +71,23 @@ public class ChromecastListActivity extends AppCompatActivity implements Adapter
   private void setupActionBar() {
     Toolbar toolbar = findViewById(R.id.toolbar);
     setSupportActionBar(toolbar);
+  }
+
+  private void setupSkinChooser() {
+    RadioGroup skinChooser = findViewById(R.id.player_type_chooser);
+    skinChooser.setOnCheckedChangeListener((radioGroup, radioButtonID) -> {
+      SampleApplication app = ((SampleApplication) getApplication());
+      switch (radioButtonID) {
+        case R.id.radioButtonSkin:
+          app.setExpandedControllerActivity(SkinCastPlayerActivity.class);
+          break;
+        case R.id.radioButtonSimple:
+          app.setExpandedControllerActivity(SimpleCastPlayerActivity.class);
+          break;
+        default:
+          app.setExpandedControllerActivity(SimpleCastPlayerActivity.class);
+      }
+    });
   }
 
   /**

--- a/ChromecastSampleApp/app/src/main/java/com/ooyala/sample/SampleApplication.java
+++ b/ChromecastSampleApp/app/src/main/java/com/ooyala/sample/SampleApplication.java
@@ -1,12 +1,14 @@
 package com.ooyala.sample;
 
+import android.app.Activity;
 import android.app.Application;
-
 import com.ooyala.cast.CastManager;
 import com.ooyala.cast.RemoteDeviceConnector;
+import com.ooyala.sample.skin.SkinCastPlayerActivity;
 
 public class SampleApplication extends Application {
   private final static String NAMESPACE = "urn:x-cast:ooyala";
+  private static Class<? extends Activity> activity = SkinCastPlayerActivity.class;
 
   @Override
   public void onCreate() {
@@ -18,5 +20,13 @@ public class SampleApplication extends Application {
       e.printStackTrace();
       throw new RuntimeException(e);
     }
+  }
+
+  public void setExpandedControllerActivity(Class<? extends Activity> activity) {
+    SampleApplication.activity = activity;
+  }
+
+  public Class<? extends Activity> getExpandedControllerActivity() {
+    return activity;
   }
 }

--- a/ChromecastSampleApp/app/src/main/java/com/ooyala/sample/common/CastActivity.java
+++ b/ChromecastSampleApp/app/src/main/java/com/ooyala/sample/common/CastActivity.java
@@ -3,7 +3,6 @@ package com.ooyala.sample.common;
 import android.os.Bundle;
 
 import com.ooyala.cast.CastManager;
-import com.ooyala.cast.CastPlayer;
 import com.ooyala.cast.RemoteDeviceConnector;
 
 import androidx.annotation.Nullable;

--- a/ChromecastSampleApp/app/src/main/java/com/ooyala/sample/common/ExpandedControllerActivity.java
+++ b/ChromecastSampleApp/app/src/main/java/com/ooyala/sample/common/ExpandedControllerActivity.java
@@ -1,0 +1,20 @@
+package com.ooyala.sample.common;
+
+import android.app.Activity;
+import android.content.Intent;
+import android.os.Bundle;
+import androidx.annotation.Nullable;
+import com.ooyala.sample.SampleApplication;
+
+/**
+ * An activity that start SimpleCastPlayerActivity or SkinCastPlayerActivity depending on the chosen skin options
+ */
+public class ExpandedControllerActivity extends Activity {
+
+  @Override
+  protected void onCreate(@Nullable Bundle savedInstanceState) {
+    super.onCreate(savedInstanceState);
+
+    startActivity(new Intent(this, ((SampleApplication) getApplication()).getExpandedControllerActivity()));
+  }
+}

--- a/ChromecastSampleApp/app/src/main/java/com/ooyala/sample/simple/SimpleCastPlayerActivity.java
+++ b/ChromecastSampleApp/app/src/main/java/com/ooyala/sample/simple/SimpleCastPlayerActivity.java
@@ -2,7 +2,8 @@ package com.ooyala.sample.simple;
 
 import android.os.Bundle;
 import android.view.Menu;
-
+import androidx.annotation.Nullable;
+import androidx.appcompat.widget.Toolbar;
 import com.google.android.gms.cast.framework.CastButtonFactory;
 import com.ooyala.android.OoyalaNotification;
 import com.ooyala.android.OoyalaPlayer;
@@ -15,9 +16,6 @@ import com.ooyala.sample.R;
 import com.ooyala.sample.common.CastActivity;
 
 import java.util.Observable;
-
-import androidx.annotation.Nullable;
-import androidx.appcompat.widget.Toolbar;
 
 public class SimpleCastPlayerActivity extends CastActivity {
 

--- a/ChromecastSampleApp/app/src/main/java/com/ooyala/sample/skin/SkinCastPlayerActivity.java
+++ b/ChromecastSampleApp/app/src/main/java/com/ooyala/sample/skin/SkinCastPlayerActivity.java
@@ -1,27 +1,17 @@
 package com.ooyala.sample.skin;
 
 import android.os.Bundle;
-import android.util.Log;
-import android.view.Menu;
-
+import androidx.annotation.Nullable;
 import com.facebook.react.modules.core.DefaultHardwareBackBtnHandler;
-import com.google.android.gms.cast.framework.CastButtonFactory;
-import com.ooyala.android.OoyalaNotification;
-import com.ooyala.android.OoyalaPlayer;
 import com.ooyala.android.configuration.Options;
 import com.ooyala.android.skin.OoyalaSkinLayout;
 import com.ooyala.android.skin.OoyalaSkinLayoutController;
 import com.ooyala.android.skin.configuration.SkinOptions;
 import com.ooyala.sample.R;
 import com.ooyala.sample.common.CastActivity;
-
 import org.json.JSONObject;
 
-import java.util.Observable;
 import java.util.Observer;
-
-import androidx.annotation.Nullable;
-import androidx.appcompat.widget.Toolbar;
 
 public class SkinCastPlayerActivity extends CastActivity implements Observer, DefaultHardwareBackBtnHandler {
   protected OoyalaSkinLayoutController playerLayoutController;

--- a/ChromecastSampleApp/app/src/main/res/layout/activity_main.xml
+++ b/ChromecastSampleApp/app/src/main/res/layout/activity_main.xml
@@ -1,11 +1,10 @@
 <?xml version="1.0" encoding="utf-8"?>
 <RelativeLayout xmlns:android="http://schemas.android.com/apk/res/android"
-    xmlns:app="http://schemas.android.com/apk/res-auto"
-    android:id="@+id/controlsLayout"
-    android:layout_width="fill_parent"
-    android:layout_height="fill_parent"
-    android:layout_gravity="center_horizontal|bottom"
-    android:orientation="vertical">
+                android:id="@+id/controlsLayout"
+                android:layout_width="fill_parent"
+                android:layout_height="fill_parent"
+                android:layout_gravity="center_horizontal|bottom"
+                android:orientation="vertical">
 
     <com.ooyala.android.skin.OoyalaSkinLayout
         android:id="@+id/ooyalaSkin"


### PR DESCRIPTION
`CastOptions` is initialized on start the app. Any modification the options via `CastContext` in runtime are not implemented in the existing ChromeCastSDK API.
`ExpandedControllerActivity` was added to start SimpleCastPlayerActivity or SkinCastPlayerActivity depending on the chosen skin options.

*ChromeCastSampleApp import issues are fixed in this PR too.
