### PR TITLE
[PLAYER-2648]"SET FIRST ASSET" and "SET SECOND ASSET" buttons disappears on toggle to and return from Fullscreen.

### DIFF
--- a/OoyalaSkinSampleApp/app/src/main/java/com/ooyala/sample/players/AssetActivity.java
+++ b/OoyalaSkinSampleApp/app/src/main/java/com/ooyala/sample/players/AssetActivity.java
@@ -3,22 +3,20 @@ package com.ooyala.sample.players;
 import android.os.Bundle;
 import android.view.View;
 import android.widget.Button;
-import android.widget.Toast;
 
 import com.ooyala.android.OoyalaException;
+import com.ooyala.android.OoyalaNotification;
 import com.ooyala.android.OoyalaPlayer;
 import com.ooyala.android.PlayerDomain;
 import com.ooyala.android.configuration.Options;
 import com.ooyala.sample.R;
-import com.ooyala.android.skin.OoyalaSkinLayout;
 import com.ooyala.android.skin.OoyalaSkinLayoutController;
 import com.ooyala.android.skin.configuration.SkinOptions;
 
 import org.json.JSONException;
 import org.json.JSONObject;
 
-import java.io.IOException;
-import java.io.InputStream;
+import java.util.Observable;
 
 /**
  * This activity illustrates how you can play basic playback video using the Skin SDK
@@ -27,84 +25,90 @@ import java.io.InputStream;
  */
 public class AssetActivity extends AbstractHookActivity {
 
-  public static String getName() {
-    return "Asset Activity";
-  }
+	public static String getName() {
+		return "Asset Activity";
+	}
 
-  @Override
-  public void onCreate(Bundle savedInstanceState) {
-    super.onCreate(savedInstanceState);
-    setContentView(R.layout.player_set_asset_layout);
+	private Button setFirstAssetButton;
+	private Button setSecondAssetButton;
 
-    completePlayerSetup(asked);
+	@Override
+	public void onCreate(Bundle savedInstanceState) {
+		super.onCreate(savedInstanceState);
+		setContentView(R.layout.player_set_asset_layout);
 
-    initButtonListeners();
-  }
+		completePlayerSetup(asked);
 
-  private void initButtonListeners() {
-    Button setFirstAssetButton = findViewById(R.id.set_first_asset);
-    setFirstAssetButton.setOnClickListener(new View.OnClickListener() {
-      @Override
-      public void onClick(View v) {
-        try {
-          player.setAsset(loadJSONFromAsset("asset1.json"));
-        } catch (JSONException e) {
-          e.printStackTrace();
-        } catch (OoyalaException e) {
-          e.printStackTrace();
-        }
-      }
-    });
+		initButtonListeners();
+	}
 
-    Button setSecondAssetButton = findViewById(R.id.set_second_asset);
-    setSecondAssetButton.setOnClickListener(new View.OnClickListener() {
-      @Override
-      public void onClick(View v) {
-        try {
-          player.setAsset(loadJSONFromAsset("asset2.json"));
-        } catch (JSONException e ) {
-          e.printStackTrace();
-        } catch (OoyalaException e) {
-          e.printStackTrace();
-        }
-      }
-    });
-  }
+	private void initButtonListeners() {
+		setFirstAssetButton = findViewById(R.id.set_first_asset);
+		setFirstAssetButton.setOnClickListener(v -> setAsset("asset1.json"));
 
-  @Override
-  void completePlayerSetup(boolean asked) {
-    if (asked) {
-      // Get the SkinLayout from our layout xml
-      skinLayout = (OoyalaSkinLayout) findViewById(R.id.ooyalaSkin);
-      // Create the OoyalaPlayer, with some built-in UI disabled
-      Options options = new Options.Builder().setShowNativeLearnMoreButton(false).setShowPromoImage(false).setUseExoPlayer(true).build();
-      player = new OoyalaPlayer(pcode, new PlayerDomain("http://www.ooyala.com"), options);
-      //Create the SkinOptions, and setup React
-      JSONObject overrides = createSkinOverrides();
-      SkinOptions skinOptions = new SkinOptions.Builder().setSkinOverrides(overrides).build();
-      playerLayoutController = new OoyalaSkinLayoutController(getApplication(), skinLayout, player, skinOptions);
-      //Add observer to listen to fullscreen open and close events
-      playerLayoutController.addObserver(this);
-      player.addObserver(this);
+		setSecondAssetButton = findViewById(R.id.set_second_asset);
+		setSecondAssetButton.setOnClickListener(v -> setAsset("asset2.json"));
+	}
 
-      try {
-        player.setAsset(loadJSONFromAsset("asset1.json"));
-      } catch (OoyalaException e) {
-        e.printStackTrace();
-      } catch (JSONException e) {
-        e.printStackTrace();
-      }
-    }
-  }
+	@Override
+	void completePlayerSetup(boolean asked) {
+		if (asked) {
+			// Get the SkinLayout from our layout xml
+			skinLayout = findViewById(R.id.ooyalaSkin);
 
-  /**
-   * Create skin overrides to show up in the skin.
-   * Default commented. Uncomment to show changes to the start screen.
-   * @return the overrides to apply to the skin.json in the assets folder
-   */
-  private JSONObject createSkinOverrides() {
-    JSONObject overrides = new JSONObject();
-    return overrides;
-  }
-  
+			// Create the OoyalaPlayer, with some built-in UI disabled
+			Options options = new Options.Builder()
+				.setShowNativeLearnMoreButton(false)
+				.setShowPromoImage(false)
+				.setUseExoPlayer(true)
+				.build();
+
+			player = new OoyalaPlayer(pcode, new PlayerDomain("http://www.ooyala.com"), options);
+
+			//Create the SkinOptions, and setup React
+			JSONObject overrides = createSkinOverrides();
+			SkinOptions skinOptions = new SkinOptions.Builder()
+				.setSkinOverrides(overrides)
+				.build();
+
+			playerLayoutController = new OoyalaSkinLayoutController(getApplication(), skinLayout, player, skinOptions);
+			//Add observer to listen to fullscreen open and close events
+			playerLayoutController.addObserver(this);
+			player.addObserver(this);
+
+			setAsset("asset1.json");
+		}
+	}
+
+	@Override
+	public void update(Observable arg0, Object notification) {
+		final String arg1 = OoyalaNotification.getNameOrUnknown(notification);
+
+		if (arg1.equalsIgnoreCase(OoyalaSkinLayoutController.FULLSCREEN_CHANGED_NOTIFICATION_NAME)) {
+			boolean isFullscreen = (boolean) ((OoyalaNotification) notification).getData();
+			setFirstAssetButton.setVisibility(isFullscreen ? View.GONE : View.VISIBLE);
+			setSecondAssetButton.setVisibility(isFullscreen ? View.GONE : View.VISIBLE);
+		}
+	}
+
+	/**
+	 * Create skin overrides to show up in the skin.
+	 * Default commented. Uncomment to show changes to the start screen.
+	 *
+	 * @return the overrides to apply to the skin.json in the assets folder
+	 */
+	private JSONObject createSkinOverrides() {
+		JSONObject overrides = new JSONObject();
+		return overrides;
+	}
+
+	private void setAsset(String asset) {
+		try {
+			player.setAsset(loadJSONFromAsset(asset));
+		} catch (JSONException e) {
+			e.printStackTrace();
+		} catch (OoyalaException e) {
+			e.printStackTrace();
+		}
+	}
 }


### PR DESCRIPTION
Hide set-asset buttons when OoyalaPlayer is in fullscreen mode